### PR TITLE
Improve "running as root" check

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -256,7 +256,7 @@ fi
 
 
 /bin/echo
-if [ "$USER" != root ]; then
+if [ "$(id -u)" -ne 0 ]; then
 	/bin/echo "Note that you should launch this script with root privileges to get accurate information"
 	/bin/echo "You can try the following command: sudo $0"
 fi


### PR DESCRIPTION
Small issue with the `USER` environment variable:
```
$ echo $USER
thib
$ sudo sh -c 'echo $USER'
thib
$ sudo -i sh -c 'echo $USER'
root
```
Rather than recommending users to use `sudo --login` / `sudo -i`, use the (very
widespread/portable) `id` program to retrieve the effective user ID
instead and don't change the recommendation.
```
$ id -u
1000
$ sudo id -u
0
$ sudo -i id -u
0
```