### PR TITLE
Detect Page Table Isolation (PTI) on RHEL7/CENTOS7

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -238,7 +238,7 @@ fi
 if grep ^flags /proc/cpuinfo | grep -qw pti; then
 	pstatus green YES
 	kpti_enabled=1
-elif dmesg | grep -Eq 'Kernel/User page tables isolation: enabled|Kernel page table isolation enabled'; then
+elif dmesg | grep -Eq 'Kernel/User page tables isolation: enabled|Kernel page table isolation enabled|x86/pti: Unmapping kernel while in userspace'; then
 	pstatus green YES
 	kpti_enabled=1
 else


### PR DESCRIPTION
RedHat has changed the message in the patch they backported to:
```x86/pti: Unmapping kernel while in userspace```

It's a bit painful to get the source/patch if you want to check.
The sources of the Centos kernel is available here: https://git.centos.org/sources/kernel/c7/b0cf50a45ee77f54c233f0f8d8f57324e266f3d8 (it's a .tar.xz)
In these sources, in linux-3.10.0-693.11.6.el7/arch/x86/mm/kaiser.c, the code contains (line 472+):
```
        } else if ((kpti_force_enabled > 0) ||
                   (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL &&
                   !kpti_force_enabled)) {
                pr_info("x86/pti: Unmapping kernel while in userspace\n");
                kaiser_enable_pcp(true);
                kaiser_enabled = 1;
        }
```