### PR TITLE
Redhat support

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -250,13 +250,13 @@ kpti_can_tell=0
 if [ -e /proc/config.gz ]; then
 	# either the running kernel exports his own config
 	kpti_can_tell=1
-	if zgrep -q '^CONFIG_PAGE_TABLE_ISOLATION=y' /proc/config.gz; then
+	if zgrep -q '^\(CONFIG_PAGE_TABLE_ISOLATION=y\|CONFIG_KAISER=y\)' /proc/config.gz; then
 		kpti_support=1
 	fi
 elif [ -e /boot/config-$(uname -r) ]; then
 	# or we can find a config file in /root with the kernel release name
 	kpti_can_tell=1
-	if grep  -q '^CONFIG_PAGE_TABLE_ISOLATION=y' /boot/config-$(uname -r); then
+	if grep  -q '^\(CONFIG_PAGE_TABLE_ISOLATION=y\|CONFIG_KAISER=y\)' /boot/config-$(uname -r); then
 		kpti_support=1
 	fi
 fi

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -199,11 +199,6 @@ case "$ibrs_enabled" in
 	*) pstatus yellow unknown;;
 esac
 
-if [ "$mounted_debugfs" = 1 ]; then
-	# umount debugfs if we did mount it ourselves
-	umount /sys/kernel/debug
-fi
-
 /bin/echo "* Mitigation 2"
 /bin/echo -n "*   Kernel compiled with retpolines: "
 # We check the RETPOLINE kernel options
@@ -299,6 +294,11 @@ elif [ -e /sys/kernel/debug/x86/pti_enabled -a "$(cat /sys/kernel/debug/x86/pti_
 	kpti_enabled=1
 else
 	pstatus red NO
+fi
+
+if [ "$mounted_debugfs" = 1 ]; then
+	# umount debugfs if we did mount it ourselves
+	umount /sys/kernel/debug
 fi
 
 /bin/echo -ne "> \033[46m\033[30mSTATUS:\033[0m "


### PR DESCRIPTION
Paths/messages on RedHat are a bit different (see https://github.com/speed47/spectre-meltdown-checker/pull/2)