### PR TITLE
Recognize 'kaiser' flag in /proc/cpuinfo

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -290,6 +290,10 @@ if grep ^flags /proc/cpuinfo | grep -qw pti; then
 	# vanilla PTI patch sets the 'pti' flag in cpuinfo
 	pstatus green YES
 	kpti_enabled=1
+elif grep ^flags /proc/cpuinfo | grep -qw kaiser; then
+	# kernel line 4.9 sets the 'kaiser' flag in cpuinfo
+	pstatus green YES
+	kpti_enabled=1
 elif [ -e /sys/kernel/debug/x86/pti_enabled ]; then
 	# RedHat Backport creates a dedicated file, see https://access.redhat.com/articles/3311301
 	kpti_enabled=$(cat /sys/kernel/debug/x86/pti_enabled 2>/dev/null)


### PR DESCRIPTION
At least kernel 4.9 sets the 'kaiser' flag in /proc/cpuinfo when page table isolation is enabled.