### PR TITLE
Add a "batch" and "verbose" mode

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -52,7 +52,7 @@ __echo()
 	msg="$@"
 	if [ "$opt_no_color" = 1 ] ; then
 		# strip ANSI color codes
-		msg=$(echo "$msg" | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")
+		msg=$(/bin/echo -e  "$msg" | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")
 	fi
 	# explicitely call /bin/echo to avoid shell builtins that might not take options
 	/bin/echo $opt -e "$msg"


### PR DESCRIPTION
The batch mode is to allow it to run on large clusters and simply grep the output.
The verbose mode is to remove some information from the default run, as it seems a bit too much

This patchset currently cannot be merged, as it was written before the nocolor patch.
I'm trying to merge it, but don't have time right now and not sure what would be the best approach.