### PR TITLE
No-color: interpret string (-e) to be able to mach \x1B

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -130,7 +130,7 @@ __echo()
 	msg="$@"
 	if [ "$opt_no_color" = 1 ] ; then
 		# strip ANSI color codes
-		msg=$(echo "$msg" | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")
+		msg=$(/bin/echo -e  "$msg" | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")
 	fi
 	# explicitely call /bin/echo to avoid shell builtins that might not take options
 	/bin/echo $opt -e "$msg"


### PR DESCRIPTION
Currently only pstatus follows "no-color", the rest is not yet covered.
Please note that unless the configuration is parsed before the header (like in #31) the header will have color