### PR TITLE
NRPE mode

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -244,6 +244,13 @@ while [ -n "$1" ]; do
 		shift
 		case "$1" in
 			text|nrpe) opt_batch_format="$1"; shift;;
+			--*) ;;    # allow subsequent flags
+			'') ;;     # allow nothing at all
+			*)
+				echo "$0: error: unknown batch format '$1'"
+				echo "$0: error: --batch expects a format from: text, nrpe"
+				exit 1 >&2
+				;;
 		esac
 	elif [ "$1" = "-v" -o "$1" = "--verbose" ]; then
 		opt_verbose=$(expr $opt_verbose + 1)

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -35,7 +35,7 @@ show_usage()
 		--no-color			Don't use color codes
 		-v, --verbose			Increase verbosity level
 		--batch				Produce machine readable output
-		--batch nrpe		Produce machine readable output formatted for NRPE
+		--batch nrpe			Produce machine readable output formatted for NRPE
 
 	IMPORTANT:
 	A false sense of security is worse than no security at all.


### PR DESCRIPTION
Adds a mode compatible with NRPE (Nagios Remote Plugin Executor) used by Nagios, Icinga and Naemon monitoring. This uses the exit codes that correspond to known results in NRPE, and produces a single-line summary output.

```sh
$ sudo ./spectre-meltdown-checker.sh --nrpe
Vulnerable: CVE-2017-5753 CVE-2017-5715 CVE-2017-5754

$ echo $?
2
```
  