### PR TITLE
Produce JSON output formatted for Puppet, Ansible, Chef...

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -324,26 +324,26 @@ pvulnstatus()
 {
 	if [ "$opt_batch" = 1 ]; then
 		case "$opt_batch_format" in
-			text) _echo 0 "$1: $2 ($3)";;
-			nrpe)
-				case "$2" in
-					UKN) nrpe_unknown="1";;
-					VULN) nrpe_critical="1"; nrpe_vuln="$nrpe_vuln $1";;
-				esac
-				;;
-			json)
-			  case "$1" in
-				  CVE-2017-5753) aka="SPECTRE VARIANT 1";;
-				  CVE-2017-5715) aka="SPECTRE VARIANT 2";;
-				  CVE-2017-5754) aka="SPECTRE VARIANT 3";;
-			  esac
-				case "$2" in
-					UKN)  is_vuln="unknown";;
-					VULN) is_vuln="true";;
-					OK)   is_vuln="false";;
-				esac
-				_echo 0 "{\"NAME\":\""$aka"\",\"CVE\":\""$1"\",\"VULNERABLE\":$is_vuln,\"INFOS\":\""$3"\"}"
-				;;
+			     text) _echo 0 "$1: $2 ($3)";;
+			     nrpe)
+			     	      case "$2" in
+			                    UKN) nrpe_unknown="1";;
+			                    VULN) nrpe_critical="1"; nrpe_vuln="$nrpe_vuln $1";;
+			            esac
+			            ;;
+			     json)
+			            case "$1" in
+			                    CVE-2017-5753) aka="SPECTRE VARIANT 1";;
+			                    CVE-2017-5715) aka="SPECTRE VARIANT 2";;
+			     	              CVE-2017-5754) aka="MELTDOWN";;
+			            esac
+			     	      case "$2" in
+			     	              UKN)  is_vuln="unknown";;
+			     	              VULN) is_vuln="true";;
+			                    OK)   is_vuln="false";;
+			            esac
+                  json_output="${json_output:-[}{\"NAME\":\""$aka"\",\"CVE\":\""$1"\",\"VULNERABLE\":$is_vuln,\"INFOS\":\""$3"\"},"
+                  ;;
 		esac
 	fi
 
@@ -854,4 +854,8 @@ if [ "$opt_batch" = 1 -a "$opt_batch_format" = "nrpe" ]; then
 	[ "$nrpe_critical" = 1 ] && exit 2  # critical
 	[ "$nrpe_unknown" = 1 ] && exit 3  # unknown
 	exit 0  # ok
+fi
+
+if [ "$opt_batch" = 1 -a "$opt_batch_format" = "json" ]; then
+	_echo 0 ${json_output%?}]
 fi

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -35,6 +35,7 @@ show_usage()
 		--no-color			Don't use color codes
 		-v, --verbose			Increase verbosity level
 		--batch text			Produce machine readable output, this is the default if --batch is specified alone
+		--batch json			Produce JSON output formatted for Puppet, Ansible, Chef...
 		--batch nrpe			Produce machine readable output formatted for NRPE
 		--variant [1,2,3]		Specify which variant you'd like to check, by default all variants are checked
 						Can be specified multiple times (e.g. --variant 2 --variant 3)
@@ -254,12 +255,12 @@ while [ -n "$1" ]; do
 		opt_verbose=0
 		shift
 		case "$1" in
-			text|nrpe) opt_batch_format="$1"; shift;;
+			text|nrpe|json) opt_batch_format="$1"; shift;;
 			--*) ;;    # allow subsequent flags
 			'') ;;     # allow nothing at all
 			*)
 				echo "$0: error: unknown batch format '$1'"
-				echo "$0: error: --batch expects a format from: text, nrpe"
+				echo "$0: error: --batch expects a format from: text, nrpe, json"
 				exit 1 >&2
 				;;
 		esac
@@ -329,6 +330,19 @@ pvulnstatus()
 					UKN) nrpe_unknown="1";;
 					VULN) nrpe_critical="1"; nrpe_vuln="$nrpe_vuln $1";;
 				esac
+				;;
+			json)
+			  case "$1" in
+				  CVE-2017-5753) aka="SPECTRE VARIANT 1";;
+				  CVE-2017-5715) aka="SPECTRE VARIANT 2";;
+				  CVE-2017-5754) aka="SPECTRE VARIANT 3";;
+			  esac
+				case "$2" in
+					UKN)  is_vuln="unknown";;
+					VULN) is_vuln="true";;
+					OK)   is_vuln="false";;
+				esac
+				_echo 0 "{\"NAME\":\""$aka"\",\"CVE\":\""$1"\",\"VULNERABLE\":$is_vuln,\"INFOS\":\""$3"\"}"
 				;;
 		esac
 	fi

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -326,7 +326,7 @@ pvulnstatus()
 		case "$opt_batch_format" in
 			     text) _echo 0 "$1: $2 ($3)";;
 			     nrpe)
-			     	      case "$2" in
+			     	    case "$2" in
 			                    UKN) nrpe_unknown="1";;
 			                    VULN) nrpe_critical="1"; nrpe_vuln="$nrpe_vuln $1";;
 			            esac
@@ -335,15 +335,15 @@ pvulnstatus()
 			            case "$1" in
 			                    CVE-2017-5753) aka="SPECTRE VARIANT 1";;
 			                    CVE-2017-5715) aka="SPECTRE VARIANT 2";;
-			     	              CVE-2017-5754) aka="MELTDOWN";;
+			     	            CVE-2017-5754) aka="MELTDOWN";;
 			            esac
 			     	      case "$2" in
-			     	              UKN)  is_vuln="unknown";;
-			     	              VULN) is_vuln="true";;
+			     	            UKN)  is_vuln="unknown";;
+			     	            VULN) is_vuln="true";;
 			                    OK)   is_vuln="false";;
 			            esac
-                  json_output="${json_output:-[}{\"NAME\":\""$aka"\",\"CVE\":\""$1"\",\"VULNERABLE\":$is_vuln,\"INFOS\":\""$3"\"},"
-                  ;;
+                        json_output="${json_output:-[}{\"NAME\":\""$aka"\",\"CVE\":\""$1"\",\"VULNERABLE\":$is_vuln,\"INFOS\":\""$3"\"},"
+                        ;;
 		esac
 	fi
 

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -323,27 +323,27 @@ pstatus()
 pvulnstatus()
 {
 	if [ "$opt_batch" = 1 ]; then
-		case "$opt_batch_format" in
-			     text) _echo 0 "$1: $2 ($3)";;
-			     nrpe)
-			     	    case "$2" in
-			                    UKN) nrpe_unknown="1";;
-			                    VULN) nrpe_critical="1"; nrpe_vuln="$nrpe_vuln $1";;
-			            esac
-			            ;;
-			     json)
-			            case "$1" in
-			                    CVE-2017-5753) aka="SPECTRE VARIANT 1";;
-			                    CVE-2017-5715) aka="SPECTRE VARIANT 2";;
-			     	            CVE-2017-5754) aka="MELTDOWN";;
-			            esac
-			     	      case "$2" in
-			     	            UKN)  is_vuln="unknown";;
-			     	            VULN) is_vuln="true";;
-			                    OK)   is_vuln="false";;
-			            esac
-                        json_output="${json_output:-[}{\"NAME\":\""$aka"\",\"CVE\":\""$1"\",\"VULNERABLE\":$is_vuln,\"INFOS\":\""$3"\"},"
-                        ;;
+                case "$opt_batch_format" in
+                        text) _echo 0 "$1: $2 ($3)";;
+                        nrpe)
+                              case "$2" in
+                                       UKN) nrpe_unknown="1";;
+                                       VULN) nrpe_critical="1"; nrpe_vuln="$nrpe_vuln $1";;
+                              esac
+                              ;;
+                        json)
+                              case "$1" in
+                                       CVE-2017-5753) aka="SPECTRE VARIANT 1";;
+                                       CVE-2017-5715) aka="SPECTRE VARIANT 2";;
+                                       CVE-2017-5754) aka="MELTDOWN";;
+                              esac
+                              case "$2" in
+                                       UKN)  is_vuln="unknown";;
+                                       VULN) is_vuln="true";;
+                                       OK)   is_vuln="false";;
+                              esac
+                              json_output="${json_output:-[}{\"NAME\":\""$aka"\",\"CVE\":\""$1"\",\"VULNERABLE\":$is_vuln,\"INFOS\":\""$3"\"},"
+                              ;;
 		esac
 	fi
 


### PR DESCRIPTION
Produce JSON for some configuration management tools like Puppet, Ansible, Chef... 

- From `facter`

```JSON
# facter -p spectre |jq .
{
  "NAME": "SPECTRE VARIANT 1",
  "CVE": "CVE-2017-5753",
  "VULNERABLE": true,
  "INFOS": "heuristic to be improved when official patches become available"
}
{
  "NAME": "SPECTRE VARIANT 2",
  "CVE": "CVE-2017-5715",
  "VULNERABLE": true,
  "INFOS": "IBRS hardware + kernel support OR kernel with retpoline are needed to mitigate the vulnerability"
}
{
  "NAME": "SPECTRE VARIANT 3",
  "CVE": "CVE-2017-5754",
  "VULNERABLE": true,
  "INFOS": "PTI is needed to mitigate the vulnerability"
}
```

- From any

```JSON
# ./spectre-meltdown-checker.sh --batch json --variant 1 |python -m json.tool
{
    "CVE": "CVE-2017-5753",
    "INFOS": "heuristic to be improved when official patches become available",
    "NAME": "SPECTRE VARIANT 1",
    "VULNERABLE": true
}
```

- Without Pretty-Print
 
```
# ./spectre-meltdown-checker.sh --batch json
{"NAME":"SPECTRE VARIANT 1","CVE":"CVE-2017-5753","VULNERABLE":true,"INFOS":"heuristic to be improved when official patches become available"}
{"NAME":"SPECTRE VARIANT 2","CVE":"CVE-2017-5715","VULNERABLE":true,"INFOS":"IBRS hardware + kernel support OR kernel with retpoline are needed to mitigate the vulnerability"}
{"NAME":"SPECTRE VARIANT 3","CVE":"CVE-2017-5754","VULNERABLE":true,"INFOS":"PTI is needed to mitigate the vulnerability"}
```