### PR TITLE
Only show the name of the script, not the full path

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -15,8 +15,8 @@ show_usage()
 {
 	cat <<EOF
 	Usage:
-		Live mode:    $0 [options] [--live]
-		Offline mode: $0 [options] [--kernel <vmlinux_file>] [--config <kernel_config>] [--map <kernel_map_file>]
+		Live mode:    `basename $0` [options] [--live]
+		Offline mode: `basename $0` [options] [--kernel <vmlinux_file>] [--config <kernel_config>] [--map <kernel_map_file>]
 
 	Modes:
 		Two modes are available.


### PR DESCRIPTION
Otherwise, we get stuff like
`		Live mode:    /home/sylvestre/dev/debian/spectre-meltdown-checker/spectre-meltdown-checker.sh [options] [--live]
`