### PR TITLE
Update detection of retpoline being enabled

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1585,9 +1585,12 @@ check_variant2()
 
 		_info_nol "  * Retpoline enabled: "
 		if [ "$opt_live" = 1 ]; then
-			# kernel adds this flag when retpoline is supported and enabled,
-			# regardless of the fact that it's minimal / full and generic / amd
-			if grep -qw retpoline /proc/cpuinfo; then
+			# If retpoline is enabled, the kernel sends this message to the log
+			# containing the specific mitigation type.
+			rp_msg='Spectre V2 : Mitigation:';
+			dmesg_grep="$rp_msg Vulnerable: |$rp_msg Mitigation: "
+			ret=$(dmesg | grep -E "$dmesg_grep")
+			if [ ! -z "$ret" ]; then
 				pstatus green YES
 			else
 				pstatus red NO

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1587,7 +1587,7 @@ check_variant2()
 		if [ "$opt_live" = 1 ]; then
 			# If retpoline is enabled, the kernel sends this message to the log
 			# containing the specific mitigation type.
-			rp_msg='Spectre V2 : Mitigation:';
+			rp_msg='Spectre V2 : ';
 			dmesg_grep="$rp_msg Vulnerable: |$rp_msg Mitigation: "
 			ret=$(dmesg | grep -E "$dmesg_grep")
 			if [ ! -z "$ret" ]; then


### PR DESCRIPTION
Older kernel versions stored the RETPOLINE aware variables in /proc/cpuinfo.
This was removed in the latest kernel released. ( https://lkml.org/lkml/2018/1/27/142 )
Instead, use dmesg to check whether it's enabled during boot time.