### PR TITLE
 ibrs can't be enabled on no ibrs cpu 

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -2122,6 +2122,10 @@ check_variant2_linux()
 				# if ibpb=2, ibrs is forcefully=0
 				pstatus blue NO "IBPB used instead of IBRS in all kernel entrypoints"
 			else
+			if [ ! "$cpuid_ibrs" = 'SPEC_CTRL' ] && [ ! "cpuid_ibrs" = 'IBRS_SUPPORT' ] && [ ! "cpuid_spec_ctrl" = -1 ]; then 
+				pstatus yellow NO; 
+				_debug "ibrs: known cpu not supporting SPEC-CTRL or IBRS"; 
+			else
 				# 0 means disabled
 				# 1 is enabled only for kernel space
 				# 2 is enabled for kernel and user space
@@ -2139,6 +2143,7 @@ check_variant2_linux()
 					3)	if [ "$ibrs_fw_enabled" = 1 ]; then pstatus green YES "for kernel and firmware code"; else pstatus green YES; fi;;
 					*)	pstatus yellow UNKNOWN;;
 				esac
+			fi
 			fi
 		else
 			pstatus blue N/A "not testable in offline mode"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -2122,10 +2122,6 @@ check_variant2_linux()
 				# if ibpb=2, ibrs is forcefully=0
 				pstatus blue NO "IBPB used instead of IBRS in all kernel entrypoints"
 			else
-			if [ ! "$cpuid_ibrs" = 'SPEC_CTRL' ] && [ ! "cpuid_ibrs" = 'IBRS_SUPPORT' ] && [ ! "cpuid_spec_ctrl" = -1 ]; then 
-				pstatus yellow NO; 
-				_debug "ibrs: known cpu not supporting SPEC-CTRL or IBRS"; 
-			else
 				# 0 means disabled
 				# 1 is enabled only for kernel space
 				# 2 is enabled for kernel and user space
@@ -2141,9 +2137,11 @@ check_variant2_linux()
 					1)	if [ "$ibrs_fw_enabled" = 1 ]; then pstatus green YES "for kernel space and firmware code"; else pstatus green YES "for kernel space"; fi;;
 					2)	if [ "$ibrs_fw_enabled" = 1 ]; then pstatus green YES "for kernel, user space, and firmware code" ; else pstatus green YES "for both kernel and user space"; fi;;
 					3)	if [ "$ibrs_fw_enabled" = 1 ]; then pstatus green YES "for kernel and firmware code"; else pstatus green YES; fi;;
-					*)	pstatus yellow UNKNOWN;;
+					*)	if [ ! "$cpuid_ibrs" = 'SPEC_CTRL' ] && [ ! "cpuid_ibrs" = 'IBRS_SUPPORT' ] && [ ! "cpuid_spec_ctrl" = -1 ]; 
+							then pstatus yellow NO; _debug "ibrs: known cpu not supporting SPEC-CTRL or IBRS"; 
+						else 
+							pstatus yellow UNKNOWN; fi;;
 				esac
-			fi
 			fi
 		else
 			pstatus blue N/A "not testable in offline mode"


### PR DESCRIPTION
If the cpu is identified, and does not support SPEC_CTRL or IBRS, then ibrs can't be enabled, even if supported by the kernel.
Instead of reporting IBRS enabled and active UNKNOWN, report IBRS enabled and active NO.
Addresses #194 