### PR TITLE
Add missing references to variants 3a & 4

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -124,6 +124,8 @@ opt_verbose=1
 opt_variant1=0
 opt_variant2=0
 opt_variant3=0
+opt_variant3a=0
+opt_variant4=0
 opt_allvariants=1
 opt_no_sysfs=0
 opt_sysfs_only=0
@@ -532,7 +534,7 @@ while [ -n "$1" ]; do
 		shift
 	elif [ "$1" = "--variant" ]; then
 		if [ -z "$2" ]; then
-			echo "$0: error: option --variant expects a parameter (1, 2 or 3)" >&2
+			echo "$0: error: option --variant expects a parameter (1, 2, 3, 3a or 4)" >&2
 			exit 255
 		fi
 		case "$2" in


### PR DESCRIPTION
Set variables to 0, and add variants 3a & 4 to error message