### PR TITLE
Var4 whitelist from common.c::cpu_no_spec_store_bypass

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -490,10 +490,10 @@ is_cpu_ssb_free()
 		fi
 	fi
 	if is_amd; then
-		if [ "$cpu_family" = "0x12"	 ] || \
-			[ "$cpu_family" = "0x11" ] || \
-			[ "$cpu_family" = "0x10" ] || \
-			[ "$cpu_family" = "0xf"	 ]; then
+		if [ "$cpu_family" = "18"      ] || \ # family 0x12
+			[ "$cpu_family" = "17" ] || \ # family 0x11
+			[ "$cpu_family" = "16" ] || \ # family 0x10
+			[ "$cpu_family" = "15" ]; then # family 0xf
 			return 0
 		fi
 	fi			

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -444,12 +444,9 @@ is_cpu_ssb_free()
 {
 	# return true (0) if the CPU isn't affected by speculative store bypass, false (1) if it does.
 	# if it's not in the list we know, return false (1).
-	# source: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/common.c#n945
-	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_PINEVIEW	},
-	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_LINCROFT	},
-	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_PENWELL		},
-	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_CLOVERVIEW	},
-	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_CEDARVIEW	},
+	# source1: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/common.c#n945
+	# source2: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/tree/arch/x86/kernel/cpu/common.c
+	# Only list CPUs that speculate but are immune, to avoid duplication of cpus listed in is_cpu_specex_free()
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_SILVERMONT1	},
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_AIRMONT		},
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_ATOM_SILVERMONT2	},
@@ -457,43 +454,30 @@ is_cpu_ssb_free()
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_CORE_YONAH		},
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_XEON_PHI_KNL		},
 	#{ X86_VENDOR_INTEL,	6,	INTEL_FAM6_XEON_PHI_KNM		},
-	#{ X86_VENDOR_CENTAUR,	5,					},
-	#{ X86_VENDOR_INTEL,	5,					},
-	#{ X86_VENDOR_NSC,	5,					},
 	#{ X86_VENDOR_AMD,	0x12,					},
 	#{ X86_VENDOR_AMD,	0x11,					},
 	#{ X86_VENDOR_AMD,	0x10,					},
 	#{ X86_VENDOR_AMD,	0xf,					},
-	#{ X86_VENDOR_ANY,	4,					},
 	parse_cpu_details
 	if is_intel; then
 		if [ "$cpu_family" = 6 ]; then
 			if [ "$cpu_model" = "$INTEL_FAM6_ATOM_AIRMONT"          ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_CEDARVIEW"   ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_CLOVERVIEW"  ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_LINCROFT"    ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_MERRIFIELD"  ]; then
-				return 0
-			elif [ "$cpu_model" = "$INTEL_FAM6_ATOM_PENWELL"        ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_PINEVIEW"    ] || \
 				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT1" ] || \
 				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT2" ] || \
-				[ "$cpu_model" = "$INTEL_FAM6_ATOM_SILVERMONT1" ]; then
+				[ "$cpu_model" = "$INTEL_FAM6_ATOM_MERRIFIELD"  ]; then
 				return 0
 			elif [ "$cpu_model" = "$INTEL_FAM6_CORE_YONAH"          ] || \
 				[ "$cpu_model" = "$INTEL_FAM6_XEON_PHI_KNL"     ] || \
 				[ "$cpu_model" = "$INTEL_FAM6_XEON_PHI_KNM"     ]; then
 				return 0
 			fi
-		elif [ "$cpu_family" = 5 ]; then
-			return 0
 		fi
 	fi
 	if is_amd; then
-		if [ "$cpu_family" = "18"      ] || \ # family 0x12
-			[ "$cpu_family" = "17" ] || \ # family 0x11
-			[ "$cpu_family" = "16" ] || \ # family 0x10
-			[ "$cpu_family" = "15" ]; then # family 0xf
+		if [ "$cpu_family" = "18" ] || \
+			[ "$cpu_family" = "17" ] || \
+			[ "$cpu_family" = "16" ] || \
+			[ "$cpu_family" = "15" ]; then 
 			return 0
 		fi
 	fi			


### PR DESCRIPTION
Variant 4 - Add function to 'whitelist' the hand-full of CPUs unaffected by speculative store bypass. 

This would allow improved determination of variant 4 status ( #189  ) of immune CPUs while waiting for the 4.17/stable patches to be backported to distro kernels. 

Source of cpu list : https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/common.c#n945)
Modeled after is_cpu_specex_free()