### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.7
+
+RUN apk --update --no-cache add kmod binutils grep perl
+
+COPY . /check
+
+ENTRYPOINT ["/check/spectre-meltdown-checker.sh"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ chmod +x spectre-meltdown-checker.sh
 sudo ./spectre-meltdown-checker.sh
 ```
 
+### Run the script in a docker container
+
+```shell
+docker build -t spectre-meltdown-checker .
+docker run --rm --privileged -v /boot:/boot:ro -v /lib/modules:/lib/modules:ro -v /dev/cpu:/dev/cpu:ro spectre-meltdown-checker
+```
+
 ## Example of script output
 
 - Intel Haswell CPU running under Ubuntu 16.04 LTS


### PR DESCRIPTION
For some purposes, it might be handy to run the script in a Docker container (CoreOS being a notable example of this, despite the existing support to launch the script in the CoreOS toolbox).