### PR TITLE
fix: line breaks in prometheus batch mode

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3111,7 +3111,7 @@ fi
 if [ "$opt_batch" = 1 ] && [ "$opt_batch_format" = "prometheus" ]; then
 	echo "# TYPE specex_vuln_status untyped"
 	echo "# HELP specex_vuln_status Exposure of system to speculative execution vulnerabilities"
-	echo "$prometheus_output"
+	echo -e "$prometheus_output"
 fi
 
 # exit with the proper exit code


### PR DESCRIPTION
The literal `\n` when using `--batch prometheus` weren't properly translated into line breaks during output, so the textfiles scraper of Prometheus' node-exporter wasn't able to import the output generated by this script.