### PR TITLE
Updated arm cortex status

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -382,8 +382,8 @@ is_cpu_vulnerable()
 				fi
 
 				# for variant4, only A57-72-73-75 are vulnerable
-				if [ "$cpuarch" = 8 ] && echo "$cpupart" | grep -Eq '^0xd0[789a]$'; then
-					_debug "checking cpu$i: arm A57-A72-A73-A75 vulnerable to variant4"
+                                if [ "$cpuarch" = 8 ]; then
+					_debug "checking cpu$i: arm A57-A72-A73-A75-A76 vulnerable to variant4"
 					variant4=vuln
 				else
 					_debug "checking cpu$i: this arm non vulnerable to variant4"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -381,13 +381,16 @@ is_cpu_vulnerable()
 					[ -z "$variant3a" ] && variant3a=immune
 				fi
 
-				# for variant4, only A57-72-73-75 are vulnerable
-                                if [ "$cpuarch" = 8 ]; then
+				# for variant4, arch 7 immune, arch 8 A57-72-73-75-76 are vulnerable
+				if [ "$cpuarch" = 7 ] && echo "$cpupart" | grep -Eq '^0x(c0[89cfe])$'; then
+					_debug "checking cpu$i: arm A8-A9-A12-A15-A17 non vulnerable to variant4"
+					variant4=immune
+				elif [ "$cpuarch" = 8 ]; then
 					_debug "checking cpu$i: arm A57-A72-A73-A75-A76 vulnerable to variant4"
 					variant4=vuln
 				else
-					_debug "checking cpu$i: this arm non vulnerable to variant4"
-					[ -z "$variant4" ] && variant4=immune
+					_debug "checking cpu$i: unknown arm processor assumed vulnerable to variant4"
+					[ -z "$variant4" ] && variant4=vulnerable
 				fi
 			fi
 			_debug "is_cpu_vulnerable: for cpu$i and so far, we have <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4>"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -397,6 +397,12 @@ is_cpu_vulnerable()
 			_debug "is_cpu_vulnerable: for cpu$i and so far, we have <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4>"
 		done
 	fi
+	_debug "is_cpu_vulnerable: temp results are <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4>"
+	[ "$variant1"  = "immune" ] && variant1=1  || variant1=0
+	[ "$variant2"  = "immune" ] && variant2=1  || variant2=0
+	[ "$variant3"  = "immune" ] && variant3=1  || variant3=0
+	[ "$variant3a" = "immune" ] && variant3a=1 || variant3a=0
+	[ "$variant4"  = "immune" ] && variant4=1  || variant4=0	
 	_debug "is_cpu_vulnerable: final results are <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4>"
 	is_cpu_vulnerable_cached=1
 	_is_cpu_vulnerable_cached "$1"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -341,12 +341,12 @@ is_cpu_vulnerable()
 			if [ -n "$cpupart" ] && [ -n "$cpuarch" ]; then
 				# Cortex-R7 and Cortex-R8 are real-time and only used in medical devices or such
 				# I can't find their CPU part number, but it's probably not that useful anyway
-				# model R7 R8 A9    A15   A17   A57   A72    A73    A75
-				# part   ?  ? 0xc09 0xc0f 0xc0e 0xd07 0xd08  0xd09  0xd0a
-				# arch  7? 7? 7     7     7     8     8      8      8
+				# model R7 R8 A8    A9    A15   A17   A57   A72    A73    A75
+				# part   ?  ? 0xc08 0xc09 0xc0f 0xc0e 0xd07 0xd08  0xd09  0xd0a
+				# arch  7? 7? 7     7     7     7     8     8      8      8
 				#
 				# variant 1 & variant 2
-				if [ "$cpuarch" = 7 ] && echo "$cpupart" | grep -Eq '^0x(c09|c0f|c0e)$'; then
+				if [ "$cpuarch" = 7 ] && echo "$cpupart" | grep -Eq '^0x(c08|c09|c0f|c0e)$'; then
 					# armv7 vulnerable chips
 					_debug "checking cpu$i: this armv7 vulnerable to spectre 1 & 2"
 					variant1=vuln

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -390,7 +390,7 @@ is_cpu_vulnerable()
 					variant4=vuln
 				else
 					_debug "checking cpu$i: unknown arm processor assumed vulnerable to variant4"
-					[ -z "$variant4" ] && variant4=vulnerable
+					[ -z "$variant4" ] && variant4=vuln
 				fi
 			fi
 			_debug "is_cpu_vulnerable: for cpu$i and so far, we have <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4>"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -402,7 +402,7 @@ is_cpu_vulnerable()
 	[ "$variant2"  = "immune" ] && variant2=1  || variant2=0
 	[ "$variant3"  = "immune" ] && variant3=1  || variant3=0
 	[ "$variant3a" = "immune" ] && variant3a=1 || variant3a=0
-	[ "$variant4"  = "immune" ] && variant4=1  || variant4=0	
+	[ "$variant4"  = "immune" ] && variant4=1  || variant4=0
 	_debug "is_cpu_vulnerable: final results are <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4>"
 	is_cpu_vulnerable_cached=1
 	_is_cpu_vulnerable_cached "$1"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -341,12 +341,12 @@ is_cpu_vulnerable()
 			if [ -n "$cpupart" ] && [ -n "$cpuarch" ]; then
 				# Cortex-R7 and Cortex-R8 are real-time and only used in medical devices or such
 				# I can't find their CPU part number, but it's probably not that useful anyway
-				# model R7 R8 A8    A9    A15   A17   A57   A72    A73    A75
-				# part   ?  ? 0xc08 0xc09 0xc0f 0xc0e 0xd07 0xd08  0xd09  0xd0a
-				# arch  7? 7? 7     7     7     7     8     8      8      8
+				# model R7 R8 A8    A9    A12   A15   A17   A57   A72    A73    A75
+				# part   ?  ? 0xc08 0xc09 0xc0c 0xc0f 0xc0e 0xd07 0xd08  0xd09  0xd0a
+				# arch  7? 7? 7     7     7     7     7     8     8      8      8
 				#
 				# variant 1 & variant 2
-				if [ "$cpuarch" = 7 ] && echo "$cpupart" | grep -Eq '^0x(c08|c09|c0f|c0e)$'; then
+				if [ "$cpuarch" = 7 ] && echo "$cpupart" | grep -Eq '^0x(c08|c09|c0c|c0f|c0e)$'; then
 					# armv7 vulnerable chips
 					_debug "checking cpu$i: this armv7 vulnerable to spectre 1 & 2"
 					variant1=vuln


### PR DESCRIPTION
[Arm Developer](https://developer.arm.com/support/arm-security-updates/speculative-processor-vulnerability)
A8 & A12 are vulnerable to Variants 1&2.
All arch 8 cortexes A57-A76 are vulnerable to variant 4.

Applies all information about vulnerabilities of ARM Cortex processors (from https://developer.arm.com/support/arm-security-updates/speculative-processor-vulnerability).

Whitelist & blacklist approach, using both vulnerable and non vulnerable status for each identified CPU, with vulnerabilities tracked cumulatively for multi CPU systems.

(Fixes false non-vulnerable status for A8 reported by @V10lator in #206  )
