### PR TITLE
add guess for Arch 64-bit kernel image on raspberry pi 3

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1321,6 +1321,8 @@ if [ "$opt_live" = 1 ]; then
 		[ -e "/boot/vmlinuz"             ] && opt_kernel="/boot/vmlinuz"
 		# Arch:
 		[ -e "/boot/vmlinuz-linux"       ] && opt_kernel="/boot/vmlinuz-linux"
+		# Arch aarch64:
+		[ -e "/boot/Image"               ] && opt_kernel="/boot/Image"
 		# Linux-Libre:
 		[ -e "/boot/vmlinuz-linux-libre" ] && opt_kernel="/boot/vmlinuz-linux-libre"
 		# pine64


### PR DESCRIPTION
adding this allows the script to detect the kernel image on 64-bit Arch running on a Raspberry Pi 3.