### PR TITLE
Add support for the kernel being within a btrfs subvolume

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1309,6 +1309,9 @@ if [ "$opt_live" = 1 ]; then
 	if [ -r /proc/cmdline ] && grep -q 'BOOT_IMAGE=' /proc/cmdline; then
 		opt_kernel=$(grep -Eo 'BOOT_IMAGE=[^ ]+' /proc/cmdline | cut -d= -f2)
 		_debug "found opt_kernel=$opt_kernel in /proc/cmdline"
+		# if the boot partition is within a btrfs subvolume, strip the subvolume name
+		# if /boot is a separate subvolume, the remainder of the code in this section should handle it
+		if echo "$opt_kernel" | grep -q "^/@"; then opt_kernel=$(echo "$opt_kernel" | sed "s:/@[^/]*::"); fi
 		# if we have a dedicated /boot partition, our bootloader might have just called it /
 		# so try to prepend /boot and see if we find anything
 		[ -e "/boot/$opt_kernel" ] && opt_kernel="/boot/$opt_kernel"


### PR DESCRIPTION
The current release fails to find my kernel due to my use of btrfs.

On my system, "/boot" is within a subvolume named "@" (a fairly standard approach to btrfs filesystem layout) and GRUB mounts the btrfs partition at the top level, meaning that it sees the boot directory at "/@/boot"; the result is that `grep -Eo 'BOOT_IMAGE=[^ ]+` returns "/@/boot/vmlinuz...". Once the system has booted however, the boot directory is found simply at "/boot", rather than "/@/boot", so the script currently reports that the kernel can't be found when running in live mode. This PR resolves this issue.

While not the case on my system (and usually advised against as being unnecessary) some users may use a separate btrfs subvolume for their "/boot" directory (eg. "@boot"), so I've written my patch to also be able to handle these, relying on the existing code used to prepend "/boot".

Some other btrfs configurations are possible (eg. putting the root filesystem directly at the top level), but these should already be catered for by the existing code.