### PR TITLE
aarch64 changes

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3061,9 +3061,14 @@ check_variant3_linux()
 		mount_debugfs
 		_info_nol "  * PTI enabled and active: "
 		if [ "$opt_live" = 1 ]; then
-			dmesg_grep="Kernel/User page tables isolation: enabled"
-			dmesg_grep="$dmesg_grep|Kernel page table isolation enabled"
-			dmesg_grep="$dmesg_grep|x86/pti: Unmapping kernel while in userspace"
+		        if [ "$(uname -m)" = "aarch64" ]; then
+			    dmesg_grep="CPU features: detected: Kernel page table isolation \(KPTI\)"
+			    dmesg_grep="$dmesg_grep|CPU features: detected feature: Kernel page table isolation \(KPTI\)"
+			else
+			    dmesg_grep="Kernel/User page tables isolation: enabled"
+			    dmesg_grep="$dmesg_grep|Kernel page table isolation enabled"
+			    dmesg_grep="$dmesg_grep|x86/pti: Unmapping kernel while in userspace"
+			fi
 			if grep ^flags "$procfs/cpuinfo" | grep -qw pti; then
 				# vanilla PTI patch sets the 'pti' flag in cpuinfo
 				_debug "kpti_enabled: found 'pti' flag in $procfs/cpuinfo"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3163,7 +3163,7 @@ check_variant3_linux()
 				if [ -n "$kpti_support" ]; then
 					if [ -e "/sys/kernel/debug/x86/pti_enabled" ]; then
 						explain "Your kernel supports PTI but it's disabled, you can enable it with \`echo 1 > /sys/kernel/debug/x86/pti_enabled\`"
-					elif grep -q -w nopti -w pti=off /proc/cmdline; then
+					elif grep -q -w -e nopti -e pti=off /proc/cmdline; then
 						explain "Your kernel supports PTI but it has been disabled on command-line, remove the nopti or pti=off option from your bootloader configuration"
 					else
 						explain "Your kernel supports PTI but it has been disabled, check \`dmesg\` right after boot to find clues why the system disabled it"


### PR DESCRIPTION
I'm not sure if $(uname -m) is the correct way to distinguish aarch64 platforms in the script. If you think it should be done differently, please, let me know.

Thanks.