### PR TITLE
add SPDX GPL-3.0 license identifier

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1,4 +1,6 @@
 #! /bin/sh
+# SPDX-License-Identifier: GPL-3.0
+#
 # Spectre & Meltdown checker
 #
 # Check for the latest version at:


### PR DESCRIPTION
The spectre-meltdown-checker.sh file is missing licensing information.
The SPDX identifier is a legally binding shorthand, which can be
used instead of the full boiler plate text.