### PR TITLE
Fix cases where a CPU ucode version is not found in $procfs/cpuinfo.

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1105,7 +1105,7 @@ parse_cpu_details()
 		cpu_model=$(   grep '^model'      "$procfs/cpuinfo" | awk '{print $3}' | grep -E '^[0-9]+$' | head -1)
 		cpu_stepping=$(grep '^stepping'   "$procfs/cpuinfo" | awk '{print $3}' | grep -E '^[0-9]+$' | head -1)
 		# read CPU ucode from $procfs/cpuinfo. fall-back to 0x0 if not found (eg: with a virtual machine)
-		cpu_ucode=$(   raw_cpu_ucode=$(grep '^microcode'  "$procfs/cpuinfo") && echo $raw_cpu_ucode | awk '{print $3}' | head -1 || echo "0x0")
+		cpu_ucode=$(   raw_cpu_ucode=$(grep '^microcode'  "$procfs/cpuinfo") && echo "$raw_cpu_ucode" | awk '{print $3}' | head -1 || echo "0x0")
 	else
 		cpu_friendly_name=$(sysctl -n hw.model)
 	fi

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1104,7 +1104,8 @@ parse_cpu_details()
 		cpu_family=$(  grep '^cpu family' "$procfs/cpuinfo" | awk '{print $4}' | grep -E '^[0-9]+$' | head -1)
 		cpu_model=$(   grep '^model'      "$procfs/cpuinfo" | awk '{print $3}' | grep -E '^[0-9]+$' | head -1)
 		cpu_stepping=$(grep '^stepping'   "$procfs/cpuinfo" | awk '{print $3}' | grep -E '^[0-9]+$' | head -1)
-		cpu_ucode=$(   grep '^microcode'  "$procfs/cpuinfo" | awk '{print $3}' | head -1)
+		# read CPU ucode from $procfs/cpuinfo. fall-back to 0x0 if not found (eg: with a virtual machine)
+		cpu_ucode=$(   raw_cpu_ucode=$(grep '^microcode'  "$procfs/cpuinfo") && echo $raw_cpu_ucode | awk '{print $3}' | head -1 || echo "0x0")
 	else
 		cpu_friendly_name=$(sysctl -n hw.model)
 	fi


### PR DESCRIPTION
When running within a virtual machine, it seems like $procfs/cpuinfo doesn't contain
a 'microcode' line, which triggers a script runtime error.
Fall back to '0x0' in this case, as other parts of the script seem to already use this
as a default value anyway.