### PR TITLE
chore: fix deprecated SPDX license identifier (#249)

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-# SPDX-License-Identifier: GPL-3.0
+# SPDX-License-Identifier: GPL-3.0-only
 #
 # Spectre & Meltdown checker
 #


### PR DESCRIPTION
The SPDX license identifier 'GPL-3.0' has been deprecated according to
<https://spdx.org/licenses/GPL-3.0.html>.
