### PR TITLE
Fix kernel detection when /lib/kernel exists on a distro

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1516,7 +1516,8 @@ if [ "$opt_live" = 1 ]; then
 		[ -e "/etc/machine-id" ] && [ -e "/boot/$(cat /etc/machine-id)/$(uname -r)/linux" ] && opt_kernel="/boot/$(cat /etc/machine-id)/$(uname -r)/linux"
 		# Clear Linux:
 		str_uname=$(uname -r)
-		[ -e "/lib/kernel" ] && opt_kernel="/lib/kernel/org.clearlinux.${str_uname##*.}.${str_uname%.*}"
+		clear_linux_kernel="/lib/kernel/org.clearlinux.${str_uname##*.}.${str_uname%.*}"
+		[ -e "$clear_linux_kernel" ] && opt_kernel=$clear_linux_kernel
 	fi
 
 	# system.map


### PR DESCRIPTION
Commit b48b2177b725 ("feat: Add Clear Linux Distro (#244)") broke kernel
detection for distros using that directory for other purposes than
storing the kernel image.

Example:
 # pacman -Qo /lib/kernel
/usr/lib/kernel/ is owned by mkinitcpio 24-2
/usr/lib/kernel/ is owned by systemd 239.2-1

Signed-off-by: Laszlo Toth <laszlth@gmail.com>