### PR TITLE
Fix detection of CVE-2018-3615 (L1TF_SGX)

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1503,6 +1503,8 @@ if [ "$opt_live" = 1 ]; then
 		[ -e "/boot/Image"               ] && opt_kernel="/boot/Image"
 		# Arch armv5/armv7:
 		[ -e "/boot/zImage"              ] && opt_kernel="/boot/zImage"
+		# Arch arm7:
+		[ -e "/boot/kernel7.img"         ] && opt_kernel="/boot/kernel7.img"
 		# Linux-Libre:
 		[ -e "/boot/vmlinuz-linux-libre" ] && opt_kernel="/boot/vmlinuz-linux-libre"
 		# pine64

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -484,7 +484,7 @@ is_cpu_vulnerable()
 	[ "$variant3a"   = "immune" ] && variant3a=1   || variant3a=0
 	[ "$variant4"    = "immune" ] && variant4=1    || variant4=0
 	[ "$variantl1tf" = "immune" ] && variantl1tf=1 || variantl1tf=0
-	[ "$variantl1tf" = "immune" ] && variantl1tf_sgx=1 || variantl1tf_sgx=0
+	variantl1tf_sgx="$variantl1tf"
 	# even if we are vulnerable to L1TF, if there's no SGX, we're safe for the original foreshadow
 	[ "$cpuid_sgx" = 0 ] && variantl1tf_sgx=1
 	_debug "is_cpu_vulnerable: final results are <$variant1> <$variant2> <$variant3> <$variant3a> <$variant4> <$variantl1tf> <$variantl1tf_sgx>"


### PR DESCRIPTION
Currently, there's a logical error, in some cases showing the system vulnerable to variant l1tf_sgx although it's not vulnerable to l1tf: The variable $variantl1tf_sgx is always initialized as 0. Fix this by initializing it with the value of $variantl1tf.

This PR sneaks in another minor change: Adding the kernel location on some Arch Linux ARM systems, such as the Raspberry PI 2, where I noticed this issue.