### PR TITLE
Remove unneeded volumes in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,3 @@ RUN apk --update --no-cache add kmod binutils grep perl
 COPY . /check
 
 ENTRYPOINT ["/check/spectre-meltdown-checker.sh"]
-
-VOLUME /boot
-VOLUME /dev/cpu
-VOLUME /lib/modules


### PR DESCRIPTION
`VOLUME` directives in a Dockerfile are **not** meant as declaration of folders which require bind-mounts on runtime! They declare directories which are supposed not to be mapped into the volatile topmost layer of the running container's unionfs. 

Usually these are directories to which the containerized application wants to write temporarily or persistently, and which needs to be persisted during container recreation or shared with other containers. `docker run` even creates an anonymous volume in case a declared `VOLUME` folder isn't bound to a named volume or a host-level directory.

All three locations `/boot`, `/dev/cpu`, and `/lib/modules` are folders (resp. a device node) which require to be bind-mounted from the host for the application to work properly. They are not supposed to be volumes for the application, though, and should not be declared on the Dockerfile.