### PR TITLE
Fix Arch kernel image detection

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -1558,8 +1558,6 @@ if [ "$opt_live" = 1 ]; then
 		[ -e "/lib/modules/$(uname -r)/vmlinuz" ] && opt_kernel="/lib/modules/$(uname -r)/vmlinuz"
 		# Slackare:
 		[ -e "/boot/vmlinuz"             ] && opt_kernel="/boot/vmlinuz"
-		# Arch:
-		[ -e "/boot/vmlinuz-linux"       ] && opt_kernel="/boot/vmlinuz-linux"
 		# Arch aarch64:
 		[ -e "/boot/Image"               ] && opt_kernel="/boot/Image"
 		# Arch armv5/armv7:


### PR DESCRIPTION
Currently, the script tries to use the wrong kernel image on Arch if an alternative kernel (`hardened`, `zen`, or `lts`) is in use. Fortunately, all the Arch kernel packages place a symlink to the kernel image as `/usr/lib/modules/$(uname -r)/vmlinuz`, so simply removing the guess for Arch fixes the issue.