### PR TITLE
improvements for xen systems

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3920,7 +3920,7 @@ check_CVE_2018_3646_linux()
 
 		_info_nol "  * Hardware-backed L1D flush supported: "
 		if [ "$opt_live" = 1 ]; then
-			if grep -qw flush_l1d "$procfs/cpuinfo"; then
+			if grep -qw flush_l1d "$procfs/cpuinfo" || [ -z "$l1d_xen_hardware" ]; then
 				pstatus green YES "performance impact of the mitigation will be greatly reduced"
 			else
 				pstatus blue NO "flush will be done in software, this is slower"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3307,6 +3307,10 @@ check_CVE_2017_5754_linux()
 				# Red Hat Backport creates a dedicated file, see https://access.redhat.com/articles/3311301
 				kpti_enabled=$(cat /sys/kernel/debug/x86/pti_enabled 2>/dev/null)
 				_debug "kpti_enabled: file /sys/kernel/debug/x86/pti_enabled exists and says: $kpti_enabled"
+			elif is_xen_dom0; then
+				pti_xen_pv_domU=$(xl dmesg | grep 'XPTI' | grep 'DomU enabled' | head -1)
+
+				[ -n "$pti_xen_pv_domU" ] && kpti_enabled=1
 			fi
 			if [ -z "$kpti_enabled" ]; then
 				dmesg_grep "$dmesg_grep"; ret=$?

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3896,10 +3896,10 @@ check_CVE_2018_3646_linux()
 							pstatus green YES "for XEN guests"
 						elif [ -z "$l1d_xen_hardware" ] && [ -z "$l1d_xen_hypervisor" ]; then
 							l1d_mode=4
-							pstatus green YES "for XEN guests (HVM only)"
+							pstatus yellow YES "for XEN guests (HVM only)"
 						elif [ -z "$l1d_xen_pv_domU" ]; then
 							l1d_mode=3
-							pstatus green YES "for XEN guests (PV only)"
+							pstatus yellow YES "for XEN guests (PV only)"
 						else
 							l1d_mode=0
 							pstatus yellow NO "for XEN guests"

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3887,9 +3887,9 @@ check_CVE_2018_3646_linux()
 					pstatus green YES "unconditional flushes"
 				else
 					if is_xen_dom0; then
-						l1d_xen_hardware=$(xl dmesg | grep -Eq 'Hardware features:' | grep -Eq 'L1D_FLUSH' | head -1)
-						l1d_xen_hypervisor=$(xl dmesg | grep -Eq 'Xen settings:' | grep -Eq 'L1D_FLUSH' | head -1)
-						l1d_xen_pv_domU=$(xl dmesg | grep -Eq 'PV L1TF shadowing:' | grep -Eq 'DomU enabled' | head -1)
+						l1d_xen_hardware=$(xl dmesg | grep 'Hardware features:' | grep 'L1D_FLUSH' | head -1)
+						l1d_xen_hypervisor=$(xl dmesg | grep 'Xen settings:' | grep 'L1D_FLUSH' | head -1)
+						l1d_xen_pv_domU=$(xl dmesg | grep 'PV L1TF shadowing:' | grep 'DomU enabled' | head -1)
 
 						if [ -z "$l1d_xen_hardware" ] && [ -z "$l1d_xen_hypervisor" ] && [ -z "$l1d_xen_pv_domU" ]; then
 							l1d_mode=5

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3343,8 +3343,8 @@ check_CVE_2017_5754_linux()
 
 
 	# Test if the current host is a Xen PV Dom0 / DomU
-	xen_pv_domo=$((is_xen_dom0))
-	xen_pv_domu=$((is_xen_domU))
+	is_xen_dom0 && xen_pv_domo=1
+	is_xen_domU && xen_pv_domu=1
 
 	if [ "$opt_live" = 1 ]; then
 		# checking whether we're running under Xen PV 64 bits. If yes, we are affected by variant3

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3891,13 +3891,13 @@ check_CVE_2018_3646_linux()
 						l1d_xen_hypervisor=$(xl dmesg | grep 'Xen settings:' | grep 'L1D_FLUSH' | head -1)
 						l1d_xen_pv_domU=$(xl dmesg | grep 'PV L1TF shadowing:' | grep 'DomU enabled' | head -1)
 
-						if [ -z "$l1d_xen_hardware" ] && [ -z "$l1d_xen_hypervisor" ] && [ -z "$l1d_xen_pv_domU" ]; then
+						if [ -n "$l1d_xen_hardware" ] && [ -n "$l1d_xen_hypervisor" ] && [ -n "$l1d_xen_pv_domU" ]; then
 							l1d_mode=5
 							pstatus green YES "for XEN guests"
-						elif [ -z "$l1d_xen_hardware" ] && [ -z "$l1d_xen_hypervisor" ]; then
+						elif [ -n "$l1d_xen_hardware" ] && [ -n "$l1d_xen_hypervisor" ]; then
 							l1d_mode=4
 							pstatus yellow YES "for XEN guests (HVM only)"
-						elif [ -z "$l1d_xen_pv_domU" ]; then
+						elif [ -n "$l1d_xen_pv_domU" ]; then
 							l1d_mode=3
 							pstatus yellow YES "for XEN guests (PV only)"
 						else
@@ -3920,7 +3920,7 @@ check_CVE_2018_3646_linux()
 
 		_info_nol "  * Hardware-backed L1D flush supported: "
 		if [ "$opt_live" = 1 ]; then
-			if grep -qw flush_l1d "$procfs/cpuinfo" || [ -z "$l1d_xen_hardware" ]; then
+			if grep -qw flush_l1d "$procfs/cpuinfo" || [ -n "$l1d_xen_hardware" ]; then
 				pstatus green YES "performance impact of the mitigation will be greatly reduced"
 			else
 				pstatus blue NO "flush will be done in software, this is slower"


### PR DESCRIPTION
there is no capability to detect mitigation on xen based systems, since they are not exposed properly via /sys/devices/system/cpu/vulnerabilities/l1tf (unknown state -> "Mitigation: PTE Inversion") and /proc/cpuinfo (missing flush_l1d flag)

see https://www.suse.com/support/kb/doc/?id=7023078

improve pti checks for dom0
see https://www.suse.com/support/kb/doc/?id=7022546