### PR TITLE
IBRS kernel reported active even if sysfs has "IBRS_FW" only (#275)

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -2695,7 +2695,7 @@ check_CVE_2017_5715_linux()
 					ibrs_fw_enabled=1
 				fi
 				# when IBRS is enabled on 4.15+, we can see it in sysfs
-				if grep -q -e 'IBRS' -e 'Indirect Branch Restricted Speculation' "/sys/devices/system/cpu/vulnerabilities/spectre_v2"; then
+				if grep -q -e '\<IBRS\>' -e 'Indirect Branch Restricted Speculation' "/sys/devices/system/cpu/vulnerabilities/spectre_v2"; then
 					_debug "ibrs: found IBRS in sysfs"
 					[ -z "$ibrs_supported" ] && ibrs_supported='found IBRS in sysfs'
 					[ -z "$ibrs_enabled"   ] && ibrs_enabled=3


### PR DESCRIPTION
On a (pre-SkyLake) system, where /sys/.../vulnerabilities/spectre_v2 is
"Mitigation: Full generic retpoline, IBPB: conditional, IBRS_FW, RSB filling"

the tool, incorrectly, reports, a couple of lines above:
* IBRS enabled and active:  YES  (for kernel and firmware code)

Use '\<IBRS\>', as suggested by @jirislaby, in issue #275 when
checking whether IBRS is enabled/active for the kernel.

With that, the output becomes:
* IBRS enabled and active:  YES  (for firmware code only)

which is actually the case.

I double checked that, if the same kernel is used on a post-SkyLake
hardware, which on openSUSE uses IBRS as, even with this change, the
tool (this time correctly) reports:
* IBRS enabled and active:  YES  (for kernel and firmware code)