### PR TITLE
Some fixes and improvements on L1TF detection and reporting on Linux

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3845,7 +3845,9 @@ check_CVE_2018_3646_linux()
 		fi
 	fi
 
-	if [ "$opt_sysfs_only" != 1 ]; then
+	# until we find it is actually off, let's assume enabled
+	ept_disabled=0
+	if [ "$opt_no_sysfs" != 1 ]; then
 		_info "* Mitigation 1 (KVM)"
 		_info_nol "  * EPT is disabled: "
 		if [ "$opt_live" = 1 ]; then
@@ -3860,7 +3862,9 @@ check_CVE_2018_3646_linux()
 		else
 			pstatus blue N/A "not testable in offline mode"
 		fi
+	fi
 
+	if [ "$opt_sysfs_only" != 1 ]; then
 		_info "* Mitigation 2"
 		_info_nol "  * L1D flush is supported by kernel: "
 		if [ "$opt_live" = 1 ] && grep -qw flush_l1d "$procfs/cpuinfo"; then

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3797,6 +3797,10 @@ check_CVE_2018_3646_linux()
 		if [ "$has_vmm" = -1 ]; then
 			# Assumed to be running on bare metal unless evidence of vm is found.
 			has_vmm=0
+			# if we have the 'kvm_intel' module loaded, well, we defintely can run VMs!
+			if lsmod | grep -q kvm_intel; then
+				has_vmm=1
+			fi
 			# test for presence of hypervisor flag - definitive if set
 			if [ -e "$procfs/cpuinfo" ] && grep ^flags "$procfs/cpuinfo" | grep -qw hypervisor; then
 				has_vmm=1

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3785,9 +3785,15 @@ check_CVE_2018_3646_linux()
 	msg=''
 	l1d_mode=-1
 
+	has_vmm=$opt_vmm
+	if sys_interface_check "/sys/devices/system/cpu/vulnerabilities/l1tf" 'VMX:.*' silent; then
+		# if we can use /sys, and it has 'VMX', we are can run VMs
+		if [ "$opt_vmm" != 0 ]; then
+			has_vmm=1;
+		fi
+	fi
 	if [ "$opt_sysfs_only" != 1 ]; then
 		_info_nol "* This system is a host running a hypervisor: "
-		has_vmm=$opt_vmm
 		if [ "$has_vmm" = -1 ]; then
 			# Assumed to be running on bare metal unless evidence of vm is found.
 			has_vmm=0

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3783,10 +3783,8 @@ check_CVE_2018_3646_linux()
 	status=UNK
 	sys_interface_available=0
 	msg=''
-	if sys_interface_check "/sys/devices/system/cpu/vulnerabilities/l1tf" 'VMX:.*' silent; then
-		# this kernel has the /sys interface, trust it over everything
-		sys_interface_available=1
-	fi
+	l1d_mode=-1
+
 	if [ "$opt_sysfs_only" != 1 ]; then
 		_info_nol "* This system is a host running a hypervisor: "
 		has_vmm=$opt_vmm
@@ -3925,16 +3923,9 @@ check_CVE_2018_3646_linux()
 		else
 			pstatus yellow UNKNOWN
 		fi
-
-	elif [ "$sys_interface_available" = 0 ]; then
-		# we have no sysfs but were asked to use it only!
-		msg="/sys vulnerability interface use forced, but it's not available!"
-		status=UNK
-		l1d_mode=-1
 	fi
 
 	if ! is_cpu_vulnerable "$cve"; then
-		# override status & msg in case CPU is not vulnerable after all
 		pvulnstatus $cve OK "your CPU vendor reported your CPU model as not vulnerable"
 	elif [ "$has_vmm" = 0 ]; then
 		pvulnstatus $cve OK "this system is not running a hypervisor"


### PR DESCRIPTION
The fundamental problem this pull request addresses is the fact that the tolls often reports that the host is not running an hypervisor, when it actually is.

In fact, if (on Linux) `/sys/devices/system/cpu/vulnerabilities/l1tf` contains `VMX: vulnerable`, that means we are running an hypervisor, and that L1TF based attacks are possible. Actually, even just the fact that the 'kvm_intel' module is loaded means that we are running an hypervisor.

This pull request makes sure that we recognize this situation. While there, it also improve a few things about the use of `--sysfs-only` and `--no-sysfs` modes.