### PR TITLE
Added support for TAA vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A shell script to tell if your system is vulnerable against the several "specula
 - CVE-2018-12130 [microarchitectural fill buffer data sampling (MFBDS)] aka 'ZombieLoad'
 - CVE-2018-12127 [microarchitectural load port data sampling (MLPDS)] aka 'RIDL'
 - CVE-2019-11091 [microarchitectural data sampling uncacheable memory (MDSUM)] aka 'RIDL'
+- CVE-2019-11135 [TSX asynchronous abort] aka 'TAA'
 
 Supported operating systems:
 - Linux (all versions, flavors and distros)
@@ -141,6 +142,12 @@ docker run --rm --privileged -v /boot:/boot:ro -v /dev/cpu:/dev/cpu:ro -v /lib/m
 **CVE-2019-11091** [MDSUM] Microarchitectural Data Sampling Uncacheable Memory (RIDL)
 
    - Note: These 4 CVEs are similar and collectively named "MDS" vulnerabilities, the mitigation is identical for all
+   - Impact: Kernel
+   - Mitigation: microcode update + kernel update making possible to protect various CPU internal buffers from unprivileged speculative access to data
+   - Performance impact of the mitigation: low to significant
+
+**CVE-2019-11135** TSX Asynchronous Abort (TAA)
+
    - Impact: Kernel
    - Mitigation: microcode update + kernel update making possible to protect various CPU internal buffers from unprivileged speculative access to data
    - Performance impact of the mitigation: low to significant

--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -629,7 +629,7 @@ is_cpu_mds_free()
 
 is_cpu_taa_free()
 {
-	# return true (0) if the CPU isn't affected by tsx asynchronnous aborts, false (1) if it does.
+	# return true (0) if the CPU isn't affected by tsx asynchronous aborts, false (1) if it does.
 	# There are three types of processors that do not require additional mitigations.
 	# 1. CPUs that do not support Intel TSX are not affected.
 	# 2. CPUs that enumerate IA32_ARCH_CAPABILITIES[TAA_NO] (bit 8)=1 are not affected.
@@ -640,7 +640,7 @@ is_cpu_taa_free()
 		return 0
 	# is intel
 	elif [ "$capabilities_taa_no" = 0 ] || \
-		[ "$rtm" = 0]; then
+		[ "$cpuid_rtm" = 0]; then
 		return 0
 	fi
 
@@ -2514,13 +2514,13 @@ check_cpu()
 		_info_nol "    * TSX support is available: "
 		read_cpuid 0x7 $EDX 11 1 1; ret=$?
 		if [ $ret -eq 0 ]; then
-			rtm=1
+			cpuid_rtm=1
 			pstatus green YES "TSX RTM feature bit"
 		elif [ $ret -eq 2 ]; then
-			rtm=-1
+			cpuid_rtm=-1
 			pstatus yellow UNKNOWN "is cpuid kernel module available?"
 		else
-			rtm=0
+			cpuid_rtm=0
 			pstatus yellow NO
 		fi
 	fi


### PR DESCRIPTION
The TSX Asynchronous Abort (TAA) vulnerability is similar to Microarchitectural Data Sampling (MDS) and affects the same buffers (store buffer, fill buffer, load port writeback data bus). The TAA condition, on some microprocessors utilizing speculative execution, may allow an authenticated user to potentially enable information disclosure via a side channel with local access. TAA has a separate CVE than MDS: CVE-2019-11135.