### PR TITLE
Support with busybox's ps command

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3070,7 +3070,13 @@ check_has_vmm()
 		else
 			# ignore SC2009 as `ps ax` is actually used as a fallback if `pgrep` isn't installed
 			# shellcheck disable=SC2009
-			if ps ax | grep -vw grep | grep -q -e '\<qemu' -e '/qemu' -e '<\kvm' -e '/kvm' -e '/xenstored' -e '/xenconsoled'; then
+			PS='ps ax'
+			# busybox's ps command does not have ax option.
+			readlink $(which ps) > /dev/null 2&>1
+			if [ $? -eq 0 ] ; then
+				PS='ps'
+			fi
+			if $PS | grep -vw grep | grep -q -e '\<qemu' -e '/qemu' -e '<\kvm' -e '/kvm' -e '/xenstored' -e '/xenconsoled'; then
 				has_vmm=1
 			fi
 		fi


### PR DESCRIPTION
busybox's ps command does not have 'ax' option.
----
CVE-2018-3620: OK (your CPU vendor reported your CPU model as not vulnerable)
ps: invalid option -- 'a'
BusyBox v1.30.1 (2020-01-07 07:47:10 UTC) multi-call binary.
Usage: ps
----

And busybox's ps command provides output similar to ax.
This supports busybox's ps command.

Signed-off-by: Nobuhiro Iwamatsu <nobuhiro1.iwamatsu@toshiba.co.jp>