### PR TITLE
Issue 429: analyse/lint and format script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,27 +1,35 @@
-name: CI
+name: Shellcheck, Shfmt and execution test
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      # Run workflow on every push
+      # only if a file within the specified paths has been changed:
+      - '*.sh'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
-  build:
-
+  sh-checker:
+    name: Shfmt Lint
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run the sh-checker
+        uses: luizm/action-sh-checker@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHELLCHECK_OPTS: -e SC1091,SC1090 # exclude some shellcheck warnings.
+          SHFMT_OPTS: -s # arguments to shfmt.
+        with:
+          sh_checker_comment: true
 
+  check-execution:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: install prerequisites
-      run: sudo apt-get update && sudo apt-get install -y shellcheck jq sqlite3 iucode-tool
-    - name: shellcheck
-      run: shellcheck -s sh spectre-meltdown-checker.sh
-    - name: check indentation
-      run: |
-        if [ $(grep -cPv "^\t*\S|^$" spectre-meltdown-checker.sh) != 0 ]; then
-          echo "Badly indented lines found:"
-          grep -nPv "^\t*\S|^$" spectre-meltdown-checker.sh
-          exit 1
-        else
-          echo "Indentation seems correct."
-        fi
+      run: sudo apt-get update && sudo apt-get install -y jq sqlite3 iucode-tool
     - name: check direct execution
       run: |
         expected=15


### PR DESCRIPTION
This PR fixes #429 by these changes:

      👷 add a fancy GitHub action for 'shellcheck' and 'shfmt'
      👷 moved 'shellcheck' and 'check indentation' to new GitHub Action
      🚨 fix 'shellcheck' warnings
      🚨 fix 'shfmt' warnings

Contrary to my expectations I had to fix some warnings in `spectre-meltdown-checker.sh` which finalize in some minor changes. 🤷🏻‍♂️ 

---

Please have a look at [my latest GitHub Action run in my forked repo](https://github.com/thomasmerz/spectre-meltdown-checker/runs/5755123225?check_suite_focus=true):

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/18568381/160849497-298d640e-5b97-411e-8c00-b090ebffead3.png">

<img width="906" alt="image" src="https://user-images.githubusercontent.com/18568381/160849560-b05b01cc-94ed-4a49-abba-e6b0bb11f054.png">

<img width="909" alt="image" src="https://user-images.githubusercontent.com/18568381/160849596-52815ff1-7f4b-4596-a929-20191770a291.png">
