### PR TITLE
fix: Neoverse V1 isn't vulnerable to Spectre 3a

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -539,6 +539,9 @@ is_cpu_affected()
 					[ -z "$variant3a" ] && variant3a=immune
 					variant4=vuln
 					_debug "checking cpu$i: armv8 A75 non affected to variant 3a"
+				elif [ "$cpuarch" = 8 ] && echo "$cpupart" | grep -q -w -e 0xd40; then
+					[ -z "$variant3a" ] && variant3a=immune
+					_debug "checking cpu$i: armv8 NeoverseV1 non affected to variant 3a"
 				elif [ "$cpuarch" = 8 ] && echo "$cpupart" | grep -q -w -e 0xd0b -e 0xd0c -e 0xd0d; then
 					variant1=vuln
 					[ -z "$variant2" ] && variant2=immune


### PR DESCRIPTION
https://developer.arm.com/Arm%20Security%20Center/Speculative%20Processor%20Vulnerability