### PR TITLE
👷 use latest major version for actions/checkout

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: install prerequisites
       run: sudo apt-get update && sudo apt-get install -y shellcheck jq sqlite3 iucode-tool
     - name: shellcheck


### PR DESCRIPTION
Use latest major version of [actions/checkout](https://github.com/actions/checkout) for GitHub Actions.