### PR TITLE
chore: docker compose v2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,11 +32,11 @@ jobs:
         else
           echo "OK $nb CVEs reported"
         fi
-    - name: check docker-compose run execution
+    - name: check docker compose run execution
       run: |
         expected=19
-        docker-compose build
-        nb=$(docker-compose run --rm spectre-meltdown-checker --batch json | jq '.[]|.CVE' | wc -l)
+        docker compose build
+        nb=$(docker compose run --rm spectre-meltdown-checker --batch json | jq '.[]|.CVE' | wc -l)
         if [ "$nb" -ne "$expected" ]; then
           echo "Invalid number of CVEs reported: $nb instead of $expected"
           exit 1

--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ sudo ./spectre-meltdown-checker.sh
 #### With docker-compose
 
 ```shell
-docker-compose build
-docker-compose run --rm spectre-meltdown-checker
+docker compose build
+docker compose run --rm spectre-meltdown-checker
 ```
+
+Note that on older versions of docker, `docker-compose` is a separate command, so you might
+need to replace the two `docker compose` occurences above by `docker-compose`.
 
 #### Without docker-compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   spectre-meltdown-checker:
     build:


### PR DESCRIPTION
The `docker-compose` command has been replaced by `docker compose`. The "version" tag has also been deprecated in docker-compose.yml.