### PR TITLE
fix: spurious local keyword broke sysfs based detection (#533)

### DIFF
--- a/spectre-meltdown-checker.sh
+++ b/spectre-meltdown-checker.sh
@@ -3329,7 +3329,7 @@ pr_info
 # Sets: ret_sys_interface_check_fullmsg
 # Returns: 0 if file matched, 1 otherwise
 sys_interface_check() {
-    local file regex mode msg mockvarname
+    local file regex mode mockvarname
     file="$1"
     regex="${2:-}"
     mode="${3:-}"


### PR DESCRIPTION
The $msg var assigned in sys_interface_check() must not be local to the func, but must capture and modify the callers' own local $msg var