### PR TITLE
doc: readme: correct markdown indentation for unordered list items

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,23 +272,23 @@ In **Hardware-only** mode, the script only reports CPU information and per-CVE h
 
 - Get the latest version of the script using `curl` *or* `wget`
 
-```bash
-curl -L https://meltdown.ovh -o spectre-meltdown-checker.sh
-wget https://meltdown.ovh -O spectre-meltdown-checker.sh
-```
+    ```bash
+    curl -L https://meltdown.ovh -o spectre-meltdown-checker.sh
+    wget https://meltdown.ovh -O spectre-meltdown-checker.sh
+    ```
 
 - Inspect the script. You never blindly run scripts you downloaded from the Internet, do you?
 
-```bash
-vim spectre-meltdown-checker.sh
-```
+    ```bash
+    vim spectre-meltdown-checker.sh
+    ```
 
 - When you're ready, run the script as root
 
-```bash
-chmod +x spectre-meltdown-checker.sh
-sudo ./spectre-meltdown-checker.sh
-```
+    ```bash
+    chmod +x spectre-meltdown-checker.sh
+    sudo ./spectre-meltdown-checker.sh
+    ```
 
 ### Using a docker container
 


### PR DESCRIPTION
This pull request fixes:

<img width="525" height="476" alt="Before screenshot" src="https://github.com/user-attachments/assets/bcff5834-7843-4757-816e-f2cdd2f8d745" />

into:

<img width="525" height="476" alt="After screenshot" src="https://github.com/user-attachments/assets/c4b06bac-d861-45bc-b44a-72cbd0c2cf78" />

Making it into an ordered list might also be a good idea, but I'll leave the matter now.

Signed-off-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>