### PR TITLE
Test

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -40,6 +40,14 @@ CVE | Name | Aliases
 [CVE-2024-45332](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-45332) | Branch Privilege Injection | BPI
 [CVE-2025-54505](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-54505) | AMD Zen1 Floating-Point Divider Stale Data Leak | FPDSS
 
+The following entries are ARM64 silicon errata that the kernel actively works around. They have no assigned CVE; they are tracked only by ARM's erratum numbers. Select them with `--errata <number>` or the associated `--variant` mnemonic.
+
+ID | Name | Affected cores
+-- | ---- | --------------
+CVE-0001-0001 | Speculative AT TLB corruption (errata 1165522, 1319367, 1319537, 1530923) | Cortex-A55/A57/A72/A76
+CVE-0001-0002 | Speculative unprivileged load (errata 2966298, 3117295) | Cortex-A510/A520
+CVE-0001-0003 | MSR SSBS not self-synchronizing (erratum 3194386 + siblings) | Cortex-A76/A77/A78/A78C/A710/A715/A720/A720AE/A725, X1/X1C/X2/X3/X4/X925, Neoverse-N1/N2/N3/V1/V2/V3/V3AE
+
 ## Am I at risk?
 
 Depending on your situation, the table below answers whether an attacker in a given position can extract data from a given target.

--- a/dist/README.md
+++ b/dist/README.md
@@ -272,23 +272,23 @@ In **Hardware-only** mode, the script only reports CPU information and per-CVE h
 
 - Get the latest version of the script using `curl` *or* `wget`
 
-```bash
-curl -L https://meltdown.ovh -o spectre-meltdown-checker.sh
-wget https://meltdown.ovh -O spectre-meltdown-checker.sh
-```
+    ```bash
+    curl -L https://meltdown.ovh -o spectre-meltdown-checker.sh
+    wget https://meltdown.ovh -O spectre-meltdown-checker.sh
+    ```
 
 - Inspect the script. You never blindly run scripts you downloaded from the Internet, do you?
 
-```bash
-vim spectre-meltdown-checker.sh
-```
+    ```bash
+    vim spectre-meltdown-checker.sh
+    ```
 
 - When you're ready, run the script as root
 
-```bash
-chmod +x spectre-meltdown-checker.sh
-sudo ./spectre-meltdown-checker.sh
-```
+    ```bash
+    chmod +x spectre-meltdown-checker.sh
+    sudo ./spectre-meltdown-checker.sh
+    ```
 
 ### Using a docker container
 

--- a/dist/doc/UNSUPPORTED_CVE_LIST.md
+++ b/dist/doc/UNSUPPORTED_CVE_LIST.md
@@ -307,3 +307,13 @@ A weakness in AMD's microcode signature verification (AES-CMAC hash) allows load
 Exploits a synchronization failure in the AMD stack engine via an undocumented MSR bit, targeting AMD SEV-SNP confidential VMs. Requires hypervisor-level (ring 0) access.
 
 **Why out of scope:** Not a transient/speculative execution side channel. This is an architectural attack on AMD SEV-SNP confidential computing that requires hypervisor access, which is outside the threat model of this tool.
+
+## No CVE — Jump Conditional Code (JCC) Erratum
+
+- **Issue:** [#329](https://github.com/speed47/spectre-meltdown-checker/issues/329)
+- **Intel whitepaper:** [Mitigations for Jump Conditional Code Erratum](https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf)
+- **Affected CPUs:** Intel 6th through 10th generation Core and Xeon processors (Skylake through Cascade Lake)
+
+A microarchitectural correctness erratum where a conditional jump instruction that straddles or ends at a 64-byte instruction fetch boundary can corrupt the branch predictor state, potentially causing incorrect execution. Intel addressed this in a November 2019 microcode update. Compilers and assemblers (GCC, LLVM, binutils) also introduced alignment options (`-mbranch-alignment`, `-x86-branches-within-32B-boundaries`) to pad jump instructions away from boundary conditions, preserving performance on CPUs with updated microcode.
+
+**Why out of scope:** The JCC erratum is a microarchitectural correctness bug, not a transient or speculative execution side-channel vulnerability. No CVE was ever assigned. Red Hat noted that privilege escalation "has not been ruled out" but made no definitive security finding, and no exploit has been demonstrated. There is no Linux sysfs entry, no CPUID bit, and no MSR flag exposing the mitigation status. The microcode fix introduces no detectable hardware indicator, so checking for it would require maintaining a per-CPU-stepping minimum microcode version table (the design principle 3 exception) — costly to maintain without a CVE anchor or confirmed exploitability to justify the ongoing work. The kernel compiler mitigation is a build-time-only change (instruction alignment) with no observable runtime state.

--- a/scripts/update_mcedb.sh
+++ b/scripts/update_mcedb.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# vim: set ts=4 sw=4 sts=4 et:
+# Regenerate src/db/200_mcedb.sh, the builtin microcode firmware database.
+#
+# This is a standalone port of the --update-builtin-fwdb logic from
+# spectre-meltdown-checker.sh. It builds the database from three sources:
+#   1. platomav's MCExtractor MCE.db (Intel + AMD microcode versions)
+#   2. Intel's official Linux Processor Microcode Data Files (takes precedence)
+#   3. linux-firmware's amd-ucode README (AMD patch levels)
+#
+# The header of src/db/200_mcedb.sh (everything before the "# %%% MCEDB" line)
+# is preserved as-is; only the version line and the data lines are regenerated.
+#
+# Requires: sqlite3, unzip, md5sum, and wget or curl.
+# Intel firmwares are listed with iucode-tool when available; otherwise a pure-shell
+# parser (needing only `od`) is used, so the script also works on arm64 where
+# iucode-tool has no package.
+#
+# Usage: scripts/update_mcedb.sh
+
+set -eu
+
+SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
+REPODIR="$(dirname "$SCRIPTDIR")"
+OUTFILE="$REPODIR/src/db/200_mcedb.sh"
+
+MCEDB_URL='https://github.com/platomav/MCExtractor/raw/master/MCE.db'
+INTEL_URL='https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/main.zip'
+LINUXFW_URL='https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd-ucode/README'
+
+# --- sanity checks ----------------------------------------------------------
+
+[ -r "$OUTFILE" ] || { echo "ERROR: cannot read $OUTFILE" >&2; exit 1; }
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || { echo "ERROR: please install the \`$1\` program" >&2; exit 1; }
+}
+need sqlite3
+need unzip
+need md5sum
+
+# iucode-tool is preferred for listing Intel microcodes, but it has no arm64
+# package, so we fall back to a pure-shell parser (parse_intel_shell) when it's
+# absent. The shell parser needs `od`, which is part of coreutils everywhere.
+if command -v iucode_tool >/dev/null 2>&1; then
+    iucode_tool=iucode_tool
+elif command -v iucode-tool >/dev/null 2>&1; then
+    iucode_tool=iucode-tool
+else
+    iucode_tool=
+    need od
+fi
+
+# download_file URL DEST
+download_file() {
+    if command -v wget >/dev/null 2>&1; then
+        wget -q -O "$2" "$1"
+    elif command -v curl >/dev/null 2>&1; then
+        curl -sL -o "$2" "$1"
+    else
+        echo "ERROR: please install either \`wget\` or \`curl\`" >&2
+        exit 1
+    fi
+}
+
+# fms2cpuid FAMILY MODEL STEPPING  -- replicates the helper from the main script
+fms2cpuid() {
+    family="$1"
+    model="$2"
+    stepping="$3"
+    if [ "$((family))" -le 15 ]; then
+        extfamily=0
+        lowfamily=$((family))
+    else
+        lowfamily=15
+        extfamily=$(((family) - 15))
+    fi
+    extmodel=$(((model & 0xF0) >> 4))
+    lowmodel=$(((model & 0x0F) >> 0))
+    echo $(((stepping & 0x0F) | (lowmodel << 4) | (lowfamily << 8) | (extmodel << 16) | (extfamily << 20)))
+}
+
+# Emit a normalized "CPUID PFMASK VERSION YYYYMMDD" line (all hex except date).
+# Args: $1=sig $2=pf $3=rev (all hex, no 0x) $4=date as stored (0xMMDDYYYY hex)
+emit_intel() {
+    _mm=${4%????}; _yyyy=${4#????}     # date is MMDDYYYY -> reorder to YYYYMMDD
+    printf '%08X %02X %08X %s\n' "$((0x$1))" "$((0x$2))" "$((0x$3))" "${_yyyy}${_mm}"
+}
+
+# Pure-shell equivalent of `iucode-tool -l`: walk every microcode in a directory
+# and print one normalized line per (signature, processor-flags) pair, including
+# those that exist only via a microcode's extended signature table.
+# The Intel microcode header is 48 bytes of little-endian uint32 fields:
+#   off 0 hdrver, 4 rev, 8 date, 12 sig, 24 pf, 28 datasize, 32 totalsize.
+# An extended signature table (if totalsize > 48+datasize) sits at 48+datasize:
+#   a 20-byte sub-header (count at off 0) then 12 bytes per entry (sig, pf, cksum).
+parse_intel_shell() {
+    for _f in "$1"/*; do
+        [ -f "$_f" ] || continue
+        _fsize=$(wc -c <"$_f")
+        _base=0
+        while [ "$_base" -lt "$_fsize" ] && [ $((_base + 48)) -le "$_fsize" ]; do
+            # shellcheck disable=SC2046  # intentional word-splitting of the 12 header words
+            set -- $(od -An -tx4 -j "$_base" -N48 "$_f" | tr '\n' ' ')
+            [ "$1" = "00000001" ] || break        # not a microcode header, stop
+            _rev=$2; _date=$3; _sig=$4; _pf=$7
+            _datasize=$((0x$8));  [ "$_datasize" = 0 ] && _datasize=2000
+            _totalsize=$((0x$9)); [ "$_totalsize" = 0 ] && _totalsize=2048
+            emit_intel "$_sig" "$_pf" "$_rev" "$_date"
+            # extended signature table, if any
+            _extbase=$((_base + 48 + _datasize))
+            if [ "$_totalsize" -gt $((48 + _datasize)) ]; then
+                _count=$((0x$(od -An -tx4 -j "$_extbase" -N4 "$_f" | tr -d ' \n')))
+                _i=0
+                while [ "$_i" -lt "$_count" ]; do
+                    _eoff=$((_extbase + 20 + _i * 12))
+                    _esig=$(od -An -tx4 -j "$_eoff"        -N4 "$_f" | tr -d ' \n')
+                    _epf=$( od -An -tx4 -j $((_eoff + 4))  -N4 "$_f" | tr -d ' \n')
+                    emit_intel "$_esig" "$_epf" "$_rev" "$_date"
+                    _i=$((_i + 1))
+                done
+            fi
+            _base=$((_base + _totalsize))
+        done
+    done
+}
+
+# List Intel microcodes as normalized "CPUID PFMASK VERSION YYYYMMDD" lines,
+# using iucode-tool when available, else the pure-shell parser.
+intel_listing() {
+    if [ -n "$iucode_tool" ]; then
+        #  079/001: sig 0x000106c2, pf_mask 0x01, 2009-04-10, rev 0x0217, size 5120
+        "$iucode_tool" -l "$1" | grep -wF sig | while read -r line; do
+            _sig=$(echo "$line" | grep -Eio 'sig 0x[0-9a-f]+' | awk '{print $2}')
+            _pf=$(echo "$line" | grep -Eio 'pf_mask 0x[0-9a-f]+' | awk '{print $2}')
+            _rev=$(echo "$line" | grep -Eio 'rev 0x[0-9a-f]+' | awk '{print $2}')
+            _date=$(echo "$line" | grep -Eo '(19|20)[0-9][0-9]-[01][0-9]-[0-3][0-9]' | tr -d '-')
+            printf '%08X %02X %08X %s\n' "$((_sig))" "$((_pf))" "$((_rev))" "$_date"
+        done
+    else
+        parse_intel_shell "$1"
+    fi
+}
+
+# --- temp files -------------------------------------------------------------
+
+MCEDB_TMP=$(mktemp -t smc-mcedb-XXXXXX)
+INTEL_TMP=$(mktemp -d -t smc-intelfw-XXXXXX)
+LINUXFW_TMP=$(mktemp -t smc-linuxfw-XXXXXX)
+DATA_TMP=$(mktemp -t smc-mcedata-XXXXXX)
+trap 'rm -rf "$MCEDB_TMP" "$INTEL_TMP" "$LINUXFW_TMP" "$DATA_TMP"' EXIT INT TERM
+
+# --- 1. fetch MCExtractor's MCE.db ------------------------------------------
+
+printf 'Fetching MCE.db from the MCExtractor project... '
+download_file "$MCEDB_URL" "$MCEDB_TMP"
+mcedb_revision=$(sqlite3 "$MCEDB_TMP" 'SELECT "revision" from "MCE"')
+[ -n "$mcedb_revision" ] || { echo "ERROR: downloaded file seems invalid" >&2; exit 1; }
+
+# add origin/pfmask columns; everything from MCE.db is tagged 'mce' with a wildcard pfmask
+sqlite3 "$MCEDB_TMP" 'ALTER TABLE "Intel" ADD COLUMN "origin" TEXT'
+sqlite3 "$MCEDB_TMP" 'ALTER TABLE "Intel" ADD COLUMN "pfmask" TEXT'
+sqlite3 "$MCEDB_TMP" 'ALTER TABLE "AMD" ADD COLUMN "origin" TEXT'
+sqlite3 "$MCEDB_TMP" 'ALTER TABLE "AMD" ADD COLUMN "pfmask" TEXT'
+sqlite3 "$MCEDB_TMP" "UPDATE \"Intel\" SET \"origin\"='mce'"
+sqlite3 "$MCEDB_TMP" "UPDATE \"Intel\" SET \"pfmask\"='FF'"
+sqlite3 "$MCEDB_TMP" "UPDATE \"AMD\" SET \"origin\"='mce'"
+sqlite3 "$MCEDB_TMP" "UPDATE \"AMD\" SET \"pfmask\"='FF'"
+echo "OK (MCExtractor database revision $mcedb_revision)"
+
+# --- 2. integrate Intel's official firmwares (these take precedence) --------
+
+printf 'Fetching Intel firmwares... '
+download_file "$INTEL_URL" "$INTEL_TMP/fw.zip"
+(cd "$INTEL_TMP" && unzip -q fw.zip)
+INTEL_UCODE_DIR="$INTEL_TMP/Intel-Linux-Processor-Microcode-Data-Files-main"
+[ -d "$INTEL_UCODE_DIR/intel-ucode" ] || { echo "ERROR: expected the 'intel-ucode' folder in the downloaded zip file" >&2; exit 1; }
+echo OK
+
+if [ -n "$iucode_tool" ]; then
+    printf 'Integrating Intel firmwares data to db (via %s)... ' "$iucode_tool"
+else
+    printf 'Integrating Intel firmwares data to db (via shell parser)... '
+fi
+intel_listing "$INTEL_UCODE_DIR/intel-ucode" | while read -r cpuid pfmask version date; do
+    # ensure the official Intel DB always has precedence over mcedb, even if mcedb has seen a more recent fw
+    sqlite3 "$MCEDB_TMP" "DELETE FROM \"Intel\" WHERE \"origin\" != 'intel' AND \"cpuid\" = '$cpuid';"
+    sqlite3 "$MCEDB_TMP" "INSERT INTO \"Intel\" (\"origin\",\"cpuid\",\"pfmask\",\"version\",\"yyyymmdd\") VALUES ('intel','$cpuid','$pfmask','$version','$date');"
+done
+
+# the license file's mtime matches the upstream last commit date
+intel_timestamp=$(stat -c %Y "$INTEL_UCODE_DIR/license" 2>/dev/null || stat -f %m "$INTEL_UCODE_DIR/license" 2>/dev/null || true)
+if [ -n "$intel_timestamp" ]; then
+    intel_latest_date=$(date -d @"$intel_timestamp" +%Y%m%d 2>/dev/null || date -r "$intel_timestamp" +%Y%m%d)
+else
+    echo "Falling back to the latest microcode date"
+    intel_latest_date=$(sqlite3 "$MCEDB_TMP" "SELECT \"yyyymmdd\" FROM \"Intel\" WHERE \"origin\"='intel' ORDER BY \"yyyymmdd\" DESC LIMIT 1;")
+fi
+echo "DONE (version $intel_latest_date)"
+
+# --- 3. integrate AMD patch levels from linux-firmware ----------------------
+
+printf 'Fetching latest amd-ucode README from linux-firmware project... '
+download_file "$LINUXFW_URL" "$LINUXFW_TMP"
+echo OK
+
+printf 'Parsing the README... '
+nbfound=0
+for line in $(grep -E 'Family=0x[0-9a-f]+ Model=0x[0-9a-f]+ Stepping=0x[0-9a-f]+: Patch=0x[0-9a-f]+' "$LINUXFW_TMP" | tr " " ","); do
+    family=$(echo "$line" | grep -Eoi 'Family=0x[0-9a-f]+' | cut -d= -f2)
+    model=$(echo "$line" | grep -Eoi 'Model=0x[0-9a-f]+' | cut -d= -f2)
+    stepping=$(echo "$line" | grep -Eoi 'Stepping=0x[0-9a-f]+' | cut -d= -f2)
+    version=$(echo "$line" | grep -Eoi 'Patch=0x[0-9a-f]+' | cut -d= -f2)
+    version=$(printf "%08X" "$((version))")
+    cpuid=$(fms2cpuid "$family" "$model" "$stepping")
+    cpuid=$(printf "%08X" "$cpuid")
+    sqlite3 "$MCEDB_TMP" "INSERT INTO \"AMD\" (\"origin\",\"cpuid\",\"pfmask\",\"version\",\"yyyymmdd\") VALUES ('linux-firmware','$cpuid','FF','$version','20000101')"
+    nbfound=$((nbfound + 1))
+done
+echo "found $nbfound microcodes"
+
+# --- 4. compute version string and dump the most recent fw per cpuid+pfmask -
+
+dbversion="$mcedb_revision+i$intel_latest_date"
+linuxfw_hash=$(md5sum "$LINUXFW_TMP" 2>/dev/null | cut -c1-4)
+[ -n "$linuxfw_hash" ] && dbversion="$dbversion+$linuxfw_hash"
+
+printf 'Building database... '
+{
+    echo "# %%% MCEDB v$dbversion"
+    sqlite3 "$MCEDB_TMP" "SELECT '# I,0x'||\"t1\".\"cpuid\"||',0x'||\"t1\".\"pfmask\"||',0x'||MAX(\"t1\".\"version\")||','||\"t1\".\"yyyymmdd\" FROM \"Intel\" AS \"t1\" LEFT OUTER JOIN \"Intel\" AS \"t2\" ON \"t2\".\"cpuid\"=\"t1\".\"cpuid\" AND \"t2\".\"pfmask\"=\"t1\".\"pfmask\" AND \"t2\".\"yyyymmdd\" > \"t1\".\"yyyymmdd\" WHERE \"t2\".\"yyyymmdd\" IS NULL GROUP BY \"t1\".\"cpuid\",\"t1\".\"pfmask\" ORDER BY \"t1\".\"cpuid\",\"t1\".\"pfmask\" ASC;" | grep -v '^# .,0x00000000,'
+    sqlite3 "$MCEDB_TMP" "SELECT '# A,0x'||\"t1\".\"cpuid\"||',0x'||\"t1\".\"pfmask\"||',0x'||MAX(\"t1\".\"version\")||','||\"t1\".\"yyyymmdd\" FROM \"AMD\"   AS \"t1\" LEFT OUTER JOIN \"AMD\"   AS \"t2\" ON \"t2\".\"cpuid\"=\"t1\".\"cpuid\" AND \"t2\".\"pfmask\"=\"t1\".\"pfmask\" AND \"t2\".\"yyyymmdd\" > \"t1\".\"yyyymmdd\" WHERE \"t2\".\"yyyymmdd\" IS NULL GROUP BY \"t1\".\"cpuid\",\"t1\".\"pfmask\" ORDER BY \"t1\".\"cpuid\",\"t1\".\"pfmask\" ASC;" | grep -v '^# .,0x00000000,'
+} >"$DATA_TMP"
+echo "DONE (version $dbversion)"
+
+# --- 5. rewrite src/db/200_mcedb.sh, preserving its header ------------------
+
+newfile=$(mktemp -t smc-builtin-XXXXXX)
+trap 'rm -rf "$MCEDB_TMP" "$INTEL_TMP" "$LINUXFW_TMP" "$DATA_TMP" "$newfile"' EXIT INT TERM
+# keep everything before the "# %%% MCEDB" line, then append the freshly built data
+awk '/^# %%% MCEDB / { exit }; { print }' "$OUTFILE" >"$newfile"
+cat "$DATA_TMP" >>"$newfile"
+cat "$newfile" >"$OUTFILE"
+
+echo "Updated $OUTFILE ($(wc -l <"$OUTFILE") lines, version $dbversion)"

--- a/src/libs/002_core_globals.sh
+++ b/src/libs/002_core_globals.sh
@@ -155,7 +155,15 @@ g_smc_system_info_line=''
 g_smc_cpu_info_line=''
 
 # CVE Registry: single source of truth for all CVE metadata.
-# Fields: cve_id|json_key_name|affected_var_suffix|complete_name_and_aliases
+# Fields: cve_id|json_key_name|affected_var_suffix|complete_name_and_aliases|arch
+#
+# The optional `arch` field gates whether the check is run at all, based on the
+# host CPU architecture and the inspected kernel architecture. Values:
+#   x86      - only relevant when host CPU or inspected kernel is x86/amd64
+#   arm      - only relevant when host CPU or inspected kernel is ARM/ARM64
+#   (empty)  - always relevant (shared logic across architectures, e.g. Spectre V1-V4)
+# The gate only applies to default "all CVEs" runs; explicit --cve/--variant/--errata
+# selection bypasses it (if the user asks for it, they get it regardless of arch).
 #
 # Three ranges of placeholder IDs are reserved when no real CVE applies:
 #   CVE-0000-NNNN: permanent placeholder for supplementary checks (--extra only)
@@ -166,42 +174,42 @@ g_smc_cpu_info_line=''
 #   CVE-9999-NNNN: temporary placeholder for real vulnerabilities awaiting CVE
 #                  assignment. Rename across the codebase once the real CVE is issued.
 readonly CVE_REGISTRY='
-CVE-2017-5753|SPECTRE VARIANT 1|variant1|Spectre Variant 1, bounds check bypass
-CVE-2017-5715|SPECTRE VARIANT 2|variant2|Spectre Variant 2, branch target injection
-CVE-2017-5754|MELTDOWN|variant3|Variant 3, Meltdown, rogue data cache load
-CVE-2018-3640|VARIANT 3A|variant3a|Variant 3a, rogue system register read
-CVE-2018-3639|VARIANT 4|variant4|Variant 4, speculative store bypass
-CVE-2018-3615|L1TF SGX|variantl1tf_sgx|Foreshadow (SGX), L1 terminal fault
-CVE-2018-3620|L1TF OS|variantl1tf|Foreshadow-NG (OS), L1 terminal fault
-CVE-2018-3646|L1TF VMM|variantl1tf|Foreshadow-NG (VMM), L1 terminal fault
-CVE-2018-12126|MSBDS|msbds|Fallout, microarchitectural store buffer data sampling (MSBDS)
-CVE-2018-12130|MFBDS|mfbds|ZombieLoad, microarchitectural fill buffer data sampling (MFBDS)
-CVE-2018-12127|MLPDS|mlpds|RIDL, microarchitectural load port data sampling (MLPDS)
-CVE-2019-11091|MDSUM|mdsum|RIDL, microarchitectural data sampling uncacheable memory (MDSUM)
-CVE-2019-11135|TAA|taa|ZombieLoad V2, TSX Asynchronous Abort (TAA)
-CVE-2018-12207|ITLBMH|itlbmh|No eXcuses, iTLB Multihit, machine check exception on page size changes (MCEPSC)
-CVE-2020-0543|SRBDS|srbds|Special Register Buffer Data Sampling (SRBDS)
-CVE-2022-21123|SBDR|mmio|Shared Buffers Data Read (SBDR), MMIO Stale Data
-CVE-2022-21125|SBDS|mmio|Shared Buffers Data Sampling (SBDS), MMIO Stale Data
-CVE-2022-21166|DRPW|mmio|Device Register Partial Write (DRPW), MMIO Stale Data
-CVE-2023-20588|DIV0|div0|Division by Zero, AMD Zen1 speculative data leak
-CVE-2023-20593|ZENBLEED|zenbleed|Zenbleed, cross-process information leak
-CVE-2022-40982|DOWNFALL|downfall|Downfall, gather data sampling (GDS)
-CVE-2022-29900|RETBLEED AMD|retbleed|Retbleed, arbitrary speculative code execution with return instructions (AMD)
-CVE-2022-29901|RETBLEED INTEL|retbleed|Retbleed, arbitrary speculative code execution with return instructions (Intel)
-CVE-2023-20569|INCEPTION|inception|Inception, return address security (RAS)
-CVE-2023-23583|REPTAR|reptar|Reptar, redundant prefix issue
-CVE-2024-36350|TSA_SQ|tsa|Transient Scheduler Attack - Store Queue (TSA-SQ)
-CVE-2024-36357|TSA_L1|tsa|Transient Scheduler Attack - L1 (TSA-L1)
-CVE-2024-28956|ITS|its|Indirect Target Selection (ITS)
-CVE-2025-40300|VMSCAPE|vmscape|VMScape, VM-exit stale branch prediction
-CVE-2023-28746|RFDS|rfds|Register File Data Sampling (RFDS)
-CVE-2024-45332|BPI|bpi|Branch Privilege Injection (BPI)
-CVE-0000-0001|SLS|sls|Straight-Line Speculation (SLS)
-CVE-2025-54505|FPDSS|fpdss|FPDSS, AMD Zen1 Floating-Point Divider Stale Data Leak
-CVE-0001-0001|ARM SPEC AT|arm_spec_at|ARM64 errata 1165522/1319367/1319537/1530923, Speculative AT TLB corruption
-CVE-0001-0002|ARM SPEC UNPRIV LOAD|arm_spec_unpriv_load|ARM64 errata 2966298/3117295, Speculative unprivileged load
-CVE-0001-0003|ARM SSBS NOSYNC|arm_ssbs_nosync|ARM64 erratum 3194386, MSR SSBS not self-synchronizing
+CVE-2017-5753|SPECTRE VARIANT 1|variant1|Spectre Variant 1, bounds check bypass|
+CVE-2017-5715|SPECTRE VARIANT 2|variant2|Spectre Variant 2, branch target injection|
+CVE-2017-5754|MELTDOWN|variant3|Variant 3, Meltdown, rogue data cache load|
+CVE-2018-3640|VARIANT 3A|variant3a|Variant 3a, rogue system register read|
+CVE-2018-3639|VARIANT 4|variant4|Variant 4, speculative store bypass|
+CVE-2018-3615|L1TF SGX|variantl1tf_sgx|Foreshadow (SGX), L1 terminal fault|x86
+CVE-2018-3620|L1TF OS|variantl1tf|Foreshadow-NG (OS), L1 terminal fault|x86
+CVE-2018-3646|L1TF VMM|variantl1tf|Foreshadow-NG (VMM), L1 terminal fault|x86
+CVE-2018-12126|MSBDS|msbds|Fallout, microarchitectural store buffer data sampling (MSBDS)|x86
+CVE-2018-12130|MFBDS|mfbds|ZombieLoad, microarchitectural fill buffer data sampling (MFBDS)|x86
+CVE-2018-12127|MLPDS|mlpds|RIDL, microarchitectural load port data sampling (MLPDS)|x86
+CVE-2019-11091|MDSUM|mdsum|RIDL, microarchitectural data sampling uncacheable memory (MDSUM)|x86
+CVE-2019-11135|TAA|taa|ZombieLoad V2, TSX Asynchronous Abort (TAA)|x86
+CVE-2018-12207|ITLBMH|itlbmh|No eXcuses, iTLB Multihit, machine check exception on page size changes (MCEPSC)|x86
+CVE-2020-0543|SRBDS|srbds|Special Register Buffer Data Sampling (SRBDS)|x86
+CVE-2022-21123|SBDR|mmio|Shared Buffers Data Read (SBDR), MMIO Stale Data|x86
+CVE-2022-21125|SBDS|mmio|Shared Buffers Data Sampling (SBDS), MMIO Stale Data|x86
+CVE-2022-21166|DRPW|mmio|Device Register Partial Write (DRPW), MMIO Stale Data|x86
+CVE-2023-20588|DIV0|div0|Division by Zero, AMD Zen1 speculative data leak|x86
+CVE-2023-20593|ZENBLEED|zenbleed|Zenbleed, cross-process information leak|x86
+CVE-2022-40982|DOWNFALL|downfall|Downfall, gather data sampling (GDS)|x86
+CVE-2022-29900|RETBLEED AMD|retbleed|Retbleed, arbitrary speculative code execution with return instructions (AMD)|x86
+CVE-2022-29901|RETBLEED INTEL|retbleed|Retbleed, arbitrary speculative code execution with return instructions (Intel)|x86
+CVE-2023-20569|INCEPTION|inception|Inception, return address security (RAS)|x86
+CVE-2023-23583|REPTAR|reptar|Reptar, redundant prefix issue|x86
+CVE-2024-36350|TSA_SQ|tsa|Transient Scheduler Attack - Store Queue (TSA-SQ)|x86
+CVE-2024-36357|TSA_L1|tsa|Transient Scheduler Attack - L1 (TSA-L1)|x86
+CVE-2024-28956|ITS|its|Indirect Target Selection (ITS)|x86
+CVE-2025-40300|VMSCAPE|vmscape|VMScape, VM-exit stale branch prediction|x86
+CVE-2023-28746|RFDS|rfds|Register File Data Sampling (RFDS)|x86
+CVE-2024-45332|BPI|bpi|Branch Privilege Injection (BPI)|x86
+CVE-0000-0001|SLS|sls|Straight-Line Speculation (SLS)|
+CVE-2025-54505|FPDSS|fpdss|FPDSS, AMD Zen1 Floating-Point Divider Stale Data Leak|x86
+CVE-0001-0001|ARM SPEC AT|arm_spec_at|ARM64 errata 1165522/1319367/1319537/1530923, Speculative AT TLB corruption|arm
+CVE-0001-0002|ARM SPEC UNPRIV LOAD|arm_spec_unpriv_load|ARM64 errata 2966298/3117295, Speculative unprivileged load|arm
+CVE-0001-0003|ARM SSBS NOSYNC|arm_ssbs_nosync|ARM64 erratum 3194386, MSR SSBS not self-synchronizing|arm
 '
 
 # Derive the supported CVE list from the registry

--- a/src/libs/002_core_globals.sh
+++ b/src/libs/002_core_globals.sh
@@ -24,6 +24,9 @@ show_usage() {
 					can be used multiple times (e.g. --variant 3a --variant l1tf). For a list use 'help'.
 		--cve CVE		specify which CVE you'd like to check, by default all supported CVEs are checked
 					can be used multiple times (e.g. --cve CVE-2017-5753 --cve CVE-2020-0543)
+		--errata NUMBER		specify a vendor-numbered erratum (e.g. ARM64 erratum 1530923) that has no CVE
+					assigned. Maps the erratum to the corresponding check. For a list use 'help'.
+					Can be used multiple times (e.g. --errata 1530923 --errata 3194386).
 
 	Check scope:
 		--no-sysfs		don't use the /sys interface even if present [Linux]
@@ -154,9 +157,12 @@ g_smc_cpu_info_line=''
 # CVE Registry: single source of truth for all CVE metadata.
 # Fields: cve_id|json_key_name|affected_var_suffix|complete_name_and_aliases
 #
-# Two ranges of placeholder IDs are reserved when no real CVE applies:
+# Three ranges of placeholder IDs are reserved when no real CVE applies:
 #   CVE-0000-NNNN: permanent placeholder for supplementary checks (--extra only)
 #                  that will never receive a real CVE (e.g. SLS, compile-time hardening).
+#   CVE-0001-NNNN: permanent placeholder for vendor-numbered errata that will never
+#                  receive a CVE (e.g. ARM64 silicon errata tracked only by erratum ID).
+#                  Selectable via --errata <number>.
 #   CVE-9999-NNNN: temporary placeholder for real vulnerabilities awaiting CVE
 #                  assignment. Rename across the codebase once the real CVE is issued.
 readonly CVE_REGISTRY='
@@ -193,6 +199,9 @@ CVE-2023-28746|RFDS|rfds|Register File Data Sampling (RFDS)
 CVE-2024-45332|BPI|bpi|Branch Privilege Injection (BPI)
 CVE-0000-0001|SLS|sls|Straight-Line Speculation (SLS)
 CVE-2025-54505|FPDSS|fpdss|FPDSS, AMD Zen1 Floating-Point Divider Stale Data Leak
+CVE-0001-0001|ARM SPEC AT|arm_spec_at|ARM64 errata 1165522/1319367/1319537/1530923, Speculative AT TLB corruption
+CVE-0001-0002|ARM SPEC UNPRIV LOAD|arm_spec_unpriv_load|ARM64 errata 2966298/3117295, Speculative unprivileged load
+CVE-0001-0003|ARM SSBS NOSYNC|arm_ssbs_nosync|ARM64 erratum 3194386, MSR SSBS not self-synchronizing
 '
 
 # Derive the supported CVE list from the registry

--- a/src/libs/200_cpu_affected.sh
+++ b/src/libs/200_cpu_affected.sh
@@ -106,6 +106,10 @@ is_cpu_affected() {
     affected_srbds=''
     affected_mmio=''
     affected_sls=''
+    # ARM64 speculation-related errata (ARM Ltd, implementer 0x41); non-ARM systems are immune below.
+    affected_arm_spec_at=''
+    affected_arm_spec_unpriv_load=''
+    affected_arm_ssbs_nosync=''
     # DIV0, FPDSS, Zenbleed and Inception are all AMD specific, look for "is_amd" below:
     _set_immune div0
     _set_immune fpdss
@@ -827,6 +831,77 @@ is_cpu_affected() {
         _infer_immune sls
     fi
 
+    # ARM64 silicon errata (speculation/security-relevant, no CVE assignments).
+    # References: arch/arm64/Kconfig (ARM64_ERRATUM_*), arch/arm64/kernel/cpu_errata.c MIDR lists.
+    # Iterates per-core (impl, part, variant, revision) tuples. Implementers currently handled:
+    #   0x41 ARM Ltd; 0x51 Qualcomm (Kryo4xx Silver for erratum 1530923).
+    # Revision ranges mirror the kernel's MIDR_RANGE/MIDR_REV_RANGE/MIDR_REV macros. A variant
+    # 'v' and revision 'p' are packed as (v<<4)|p for range compares — equivalent to the kernel's
+    # layout (MIDR_VARIANT_SHIFT=20, MIDR_REVISION_MASK=0xf) under the same order semantics.
+    # Unknown variant/revision ⇒ treat as in range (whitelist principle, DEVELOPMENT.md rule 5).
+    if [ -n "$cpu_part_list" ]; then
+        i=0
+        for cpupart in $cpu_part_list; do
+            i=$((i + 1))
+            # shellcheck disable=SC2086
+            cpuimpl=$(echo $cpu_impl_list | awk '{print $'$i'}')
+            # shellcheck disable=SC2086
+            cpuvar=$(echo $cpu_variant_list | awk '{print $'$i'}')
+            # shellcheck disable=SC2086
+            cpurev=$(echo $cpu_revision_list | awk '{print $'$i'}')
+            packed=''
+            [ -n "$cpuvar" ] && [ -n "$cpurev" ] && packed=$(((cpuvar << 4) | cpurev))
+
+            # Speculative AT TLB corruption (errata 1165522, 1319367, 1319537, 1530923)
+            if [ "$cpuimpl" = 0x41 ]; then
+                if echo "$cpupart" | grep -q -w -e 0xd07 -e 0xd08; then
+                    # Cortex-A57 (0xd07) / A72 (0xd08): all revisions
+                    _set_vuln arm_spec_at
+                elif echo "$cpupart" | grep -q -w -e 0xd05 -e 0xd0b; then
+                    # Cortex-A55 (0xd05) / A76 (0xd0b): r0p0..r2p0  (packed 0..32)
+                    if [ -z "$packed" ] || [ "$packed" -le 32 ]; then
+                        _set_vuln arm_spec_at
+                    fi
+                fi
+            elif [ "$cpuimpl" = 0x51 ] && [ "$cpupart" = 0x805 ]; then
+                # Qualcomm Kryo4xx Silver: kernel matches MIDR_REV(var 0xd, rev 0xe) only — packed 0xde = 222
+                if [ -z "$packed" ] || [ "$packed" = 222 ]; then
+                    _set_vuln arm_spec_at
+                fi
+            fi
+
+            # Speculative unprivileged load (errata 2966298 A520, 3117295 A510) — ARM Ltd only
+            if [ "$cpuimpl" = 0x41 ]; then
+                if [ "$cpupart" = 0xd46 ]; then
+                    # Cortex-A510: all revisions
+                    _set_vuln arm_spec_unpriv_load
+                elif [ "$cpupart" = 0xd80 ]; then
+                    # Cortex-A520: r0p0..r0p1  (packed 0..1)
+                    if [ -z "$packed" ] || [ "$packed" -le 1 ]; then
+                        _set_vuln arm_spec_unpriv_load
+                    fi
+                fi
+            fi
+
+            # MSR SSBS not self-synchronizing (erratum 3194386 + siblings) — ARM Ltd only, all revisions.
+            # A76/A77/A78/A78C/A710/A715/A720/A720AE/A725, X1/X1C/X2/X3/X4/X925, N1/N2/N3, V1/V2/V3/V3AE
+            if [ "$cpuimpl" = 0x41 ]; then
+                if echo "$cpupart" | grep -q -w \
+                    -e 0xd0b -e 0xd0d -e 0xd41 -e 0xd4b \
+                    -e 0xd47 -e 0xd4d -e 0xd81 -e 0xd89 -e 0xd87 \
+                    -e 0xd44 -e 0xd4c -e 0xd48 -e 0xd4e -e 0xd82 -e 0xd85 \
+                    -e 0xd0c -e 0xd49 -e 0xd8e \
+                    -e 0xd40 -e 0xd4f -e 0xd84 -e 0xd83; then
+                    _set_vuln arm_ssbs_nosync
+                fi
+            fi
+        done
+    fi
+    # Default everything else to immune (covers non-ARM, and ARM cores not in the affected lists)
+    _infer_immune arm_spec_at
+    _infer_immune arm_spec_unpriv_load
+    _infer_immune arm_ssbs_nosync
+
     # shellcheck disable=SC2154
     {
         pr_debug "is_cpu_affected: final results: variant1=$affected_variant1 variant2=$affected_variant2 variant3=$affected_variant3 variant3a=$affected_variant3a"
@@ -834,6 +909,7 @@ is_cpu_affected() {
         pr_debug "is_cpu_affected: final results: mlpds=$affected_mlpds mdsum=$affected_mdsum taa=$affected_taa itlbmh=$affected_itlbmh srbds=$affected_srbds"
         pr_debug "is_cpu_affected: final results: div0=$affected_div0 fpdss=$affected_fpdss zenbleed=$affected_zenbleed inception=$affected_inception retbleed=$affected_retbleed tsa=$affected_tsa downfall=$affected_downfall reptar=$affected_reptar rfds=$affected_rfds its=$affected_its"
         pr_debug "is_cpu_affected: final results: vmscape=$affected_vmscape bpi=$affected_bpi sls=$affected_sls mmio=$affected_mmio"
+        pr_debug "is_cpu_affected: final results: arm_spec_at=$affected_arm_spec_at arm_spec_unpriv_load=$affected_arm_spec_unpriv_load arm_ssbs_nosync=$affected_arm_ssbs_nosync"
     }
     affected_variantl1tf_sgx="$affected_variantl1tf"
     # even if we are affected to L1TF, if there's no SGX, we're not affected to the original foreshadow

--- a/src/libs/200_cpu_affected.sh
+++ b/src/libs/200_cpu_affected.sh
@@ -27,6 +27,36 @@ _infer_immune() { eval "[ -z \"\$affected_$1\" ] && affected_$1=1 || :"; }
 # Use for: family-level catch-all fallbacks (Intel L1TF non-whitelist, itlbmh non-whitelist).
 _infer_vuln() { eval "[ -z \"\$affected_$1\" ] && affected_$1=0 || :"; }
 
+# Return 0 (true) if a CVE's arch tag matches the current context (host CPU
+# and/or target kernel), so the check is worth running. Untagged CVEs are
+# always relevant.
+# - In no-hw mode the host CPU is ignored: gate only on target kernel arch.
+# - Otherwise a match on either the host CPU or the target kernel is enough
+#   (they normally agree in live mode; if they disagree, check_kernel_cpu_arch_mismatch
+#    has already forced no-hw, handled by the branch above).
+# Args: $1=cve_id
+# Callers: src/main.sh (CVE dispatch loop), check_cpu_vulnerabilities
+_is_cve_relevant_arch() {
+    local arch
+    arch=$(_cve_registry_field "$1" 5)
+    # Untagged CVE: always relevant
+    [ -z "$arch" ] && return 0
+    case "$arch" in
+        x86)
+            [ "$g_mode" != no-hw ] && is_x86_cpu && return 0
+            is_x86_kernel && return 0
+            return 1
+            ;;
+        arm)
+            [ "$g_mode" != no-hw ] && is_arm_cpu && return 0
+            is_arm_kernel && return 0
+            return 1
+            ;;
+    esac
+    # Unknown tag value: don't gate (fail open)
+    return 0
+}
+
 # Return the cached affected_* status for a given CVE
 # Args: $1=cve_id
 # Returns: 0 if affected, 1 if not affected

--- a/src/libs/210_cpu_detect.sh
+++ b/src/libs/210_cpu_detect.sh
@@ -187,58 +187,76 @@ is_cpu_srbds_free() {
 
 }
 
+# Check whether the CPU is architecturally immune to MMIO Stale Data
+# Mirrors the kernel's arch_cap_mmio_immune() helper: ALL THREE ARCH_CAP bits must be set:
+#   ARCH_CAP_SBDR_SSDP_NO (bit 13), ARCH_CAP_FBSDP_NO (bit 14), ARCH_CAP_PSDP_NO (bit 15)
+# Returns: 0 if immune, 1 otherwise
+is_arch_cap_mmio_immune() {
+    [ "$cap_sbdr_ssdp_no" = 1 ] && [ "$cap_fbsdp_no" = 1 ] && [ "$cap_psdp_no" = 1 ]
+}
+
 # Check whether the CPU is known to be unaffected by MMIO Stale Data (CVE-2022-21123/21125/21166)
+# Matches the kernel's NO_MMIO whitelist plus arch_cap_mmio_immune().
+# Model inventory and kernel-commit history are documented in check_mmio_linux().
 # Returns: 0 if MMIO-free, 1 if affected or unknown
 is_cpu_mmio_free() {
-    # source: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/cpu/common.c
-    #
-    # CPU affection logic from kernel (51802186158c, v5.19):
-    #   Bug is set when: cpu_matches(blacklist, MMIO) AND NOT arch_cap_mmio_immune()
-    #   arch_cap_mmio_immune() requires ALL THREE bits set:
-    #     ARCH_CAP_FBSDP_NO (bit 14) AND ARCH_CAP_PSDP_NO (bit 15) AND ARCH_CAP_SBDR_SSDP_NO (bit 13)
-    #
-    # Intel Family 6 model blacklist (unchanged since v5.19):
-    #   HASWELL_X (0x3F)
-    #   BROADWELL_D (0x56), BROADWELL_X (0x4F)
-    #   SKYLAKE_X (0x55), SKYLAKE_L (0x4E), SKYLAKE (0x5E)
-    #   KABYLAKE_L (0x8E), KABYLAKE (0x9E)
-    #   ICELAKE_L (0x7E), ICELAKE_D (0x6C), ICELAKE_X (0x6A)
-    #   COMETLAKE (0xA5), COMETLAKE_L (0xA6)
-    #   LAKEFIELD (0x8A)
-    #   ROCKETLAKE (0xA7)
-    #   ATOM_TREMONT (0x96), ATOM_TREMONT_D (0x86), ATOM_TREMONT_L (0x9C)
-    #
-    # Vendor scope: Intel only. Non-Intel CPUs are not affected.
     parse_cpu_details
-    # ARCH_CAP immunity: all three bits must be set
-    if [ "$cap_sbdr_ssdp_no" = 1 ] && [ "$cap_fbsdp_no" = 1 ] && [ "$cap_psdp_no" = 1 ]; then
+    is_arch_cap_mmio_immune && return 0
+    # Non-Intel x86 vendors the kernel unconditionally whitelists (AMD/Hygon all
+    # families; Centaur/Zhaoxin fam 7 only).
+    if is_amd || is_hygon; then
         return 0
     fi
-    if is_intel; then
-        if [ "$cpu_family" = 6 ]; then
-            if [ "$cpu_model" = "$INTEL_FAM6_HASWELL_X" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_BROADWELL_D" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_BROADWELL_X" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_SKYLAKE_X" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_SKYLAKE_L" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_SKYLAKE" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_KABYLAKE_L" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_KABYLAKE" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_ICELAKE_L" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_ICELAKE_D" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_ICELAKE_X" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_COMETLAKE" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_COMETLAKE_L" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_LAKEFIELD" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_ROCKETLAKE" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_ATOM_TREMONT" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_ATOM_TREMONT_D" ] ||
-                [ "$cpu_model" = "$INTEL_FAM6_ATOM_TREMONT_L" ]; then
-                return 1
-            fi
+    if { [ "$cpu_vendor" = "CentaurHauls" ] || [ "$cpu_vendor" = "Shanghai" ]; } && [ "$cpu_family" = 7 ]; then
+        return 0
+    fi
+    # Intel NO_MMIO whitelist
+    if is_intel && [ "$cpu_family" = 6 ]; then
+        if [ "$cpu_model" = "$INTEL_FAM6_TIGERLAKE" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_TIGERLAKE_L" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ALDERLAKE" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ALDERLAKE_L" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT_D" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ATOM_GOLDMONT_PLUS" ]; then
+            return 0
         fi
     fi
+    return 1
+}
 
+# Check whether the CPU's MMIO Stale Data status is unknown ("out of servicing period")
+# Matches the kernel's X86_BUG_MMIO_UNKNOWN: Intel CPU not MMIO-free and not in the
+# MMIO blacklist. The kernel reports "Unknown: No mitigations" for such CPUs.
+# Callers: check_mmio_linux, check_mmio_bsd
+# Returns: 0 if unknown, 1 if known (either affected or not affected)
+is_cpu_mmio_unknown() {
+    parse_cpu_details
+    # Only Intel can reach the unknown bucket — other x86 vendors are whitelisted by vendor-id.
+    is_intel || return 1
+    is_cpu_mmio_free && return 1
+    if [ "$cpu_family" = 6 ]; then
+        if [ "$cpu_model" = "$INTEL_FAM6_HASWELL_X" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_BROADWELL_D" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_BROADWELL_X" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_SKYLAKE_X" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_SKYLAKE_L" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_SKYLAKE" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_KABYLAKE_L" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_KABYLAKE" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ICELAKE_L" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ICELAKE_D" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ICELAKE_X" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_COMETLAKE" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_COMETLAKE_L" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_LAKEFIELD" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ROCKETLAKE" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ATOM_TREMONT" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ATOM_TREMONT_D" ] ||
+            [ "$cpu_model" = "$INTEL_FAM6_ATOM_TREMONT_L" ]; then
+            return 1
+        fi
+    fi
     return 0
 }
 

--- a/src/libs/230_util_optparse.sh
+++ b/src/libs/230_util_optparse.sh
@@ -170,7 +170,7 @@ while [ -n "${1:-}" ]; do
         case "$2" in
             help)
                 echo "The following parameters are supported for --variant (can be used multiple times):"
-                echo "1, 2, 3, 3a, 4, msbds, mfbds, mlpds, mdsum, l1tf, taa, mcepsc, srbds, mmio, sbdr, sbds, drpw, div0, fpdss, zenbleed, downfall, retbleed, inception, reptar, rfds, tsa, tsa-sq, tsa-l1, its, vmscape, bpi, sls"
+                echo "1, 2, 3, 3a, 4, msbds, mfbds, mlpds, mdsum, l1tf, taa, mcepsc, srbds, mmio, sbdr, sbds, drpw, div0, fpdss, zenbleed, downfall, retbleed, inception, reptar, rfds, tsa, tsa-sq, tsa-l1, its, vmscape, bpi, sls, arm-spec-at, arm-spec-unpriv-load, arm-ssbs-nosync"
                 exit 0
                 ;;
             1)
@@ -301,8 +301,56 @@ while [ -n "${1:-}" ]; do
                 opt_cve_list="$opt_cve_list CVE-0000-0001"
                 opt_cve_all=0
                 ;;
+            arm-spec-at)
+                opt_cve_list="$opt_cve_list CVE-0001-0001"
+                opt_cve_all=0
+                ;;
+            arm-spec-unpriv-load)
+                opt_cve_list="$opt_cve_list CVE-0001-0002"
+                opt_cve_all=0
+                ;;
+            arm-ssbs-nosync)
+                opt_cve_list="$opt_cve_list CVE-0001-0003"
+                opt_cve_all=0
+                ;;
             *)
                 echo "$0: error: invalid parameter '$2' for --variant, see --variant help for a list" >&2
+                exit 255
+                ;;
+        esac
+        shift 2
+    elif [ "$1" = "--errata" ]; then
+        # Vendor-numbered errata selector (currently ARM64). Maps an erratum number
+        # (e.g. 1530923) to the CVE-0001-NNNN check that covers it.
+        if [ -z "$2" ]; then
+            echo "$0: error: option --errata expects a parameter (an erratum number, e.g. 1530923, or 'help')" >&2
+            exit 255
+        fi
+        case "$2" in
+            help)
+                echo "The following erratum numbers are supported for --errata (can be used multiple times):"
+                echo "  Speculative AT TLB corruption:       1165522, 1319367, 1319537, 1530923"
+                echo "  Speculative unprivileged load:       2966298, 3117295"
+                echo "  MSR SSBS not self-synchronizing:     3194386 (and siblings: 3312417, 3324334, 3324335,"
+                echo "                                       3324336, 3324338, 3324339, 3324341, 3324344, 3324346,"
+                echo "                                       3324347, 3324348, 3324349, 3456084, 3456091, 3456106,"
+                echo "                                       3456111)"
+                exit 0
+                ;;
+            1165522 | 1319367 | 1319537 | 1530923)
+                opt_cve_list="$opt_cve_list CVE-0001-0001"
+                opt_cve_all=0
+                ;;
+            2966298 | 3117295)
+                opt_cve_list="$opt_cve_list CVE-0001-0002"
+                opt_cve_all=0
+                ;;
+            3194386 | 3312417 | 3324334 | 3324335 | 3324336 | 3324338 | 3324339 | 3324341 | 3324344 | 3324346 | 3324347 | 3324348 | 3324349 | 3456084 | 3456091 | 3456106 | 3456111)
+                opt_cve_list="$opt_cve_list CVE-0001-0003"
+                opt_cve_all=0
+                ;;
+            *)
+                echo "$0: error: unsupported erratum number '$2' for --errata, see --errata help for a list" >&2
                 exit 255
                 ;;
         esac

--- a/src/libs/250_output_emitters.sh
+++ b/src/libs/250_output_emitters.sh
@@ -110,7 +110,8 @@ _build_json_system() {
         1) smt_val='false' ;;
         *) smt_val='null' ;;
     esac
-    g_json_system=$(printf '{"kernel_release":%s,"kernel_version":%s,"kernel_arch":%s,"kernel_image":%s,"kernel_config":%s,"kernel_version_string":%s,"kernel_cmdline":%s,"cpu_count":%s,"smt_enabled":%s,"hypervisor_host":%s,"hypervisor_host_reason":%s}' \
+    is_running_as_guest || true
+    g_json_system=$(printf '{"kernel_release":%s,"kernel_version":%s,"kernel_arch":%s,"kernel_image":%s,"kernel_config":%s,"kernel_version_string":%s,"kernel_cmdline":%s,"cpu_count":%s,"smt_enabled":%s,"hypervisor_host":%s,"hypervisor_host_reason":%s,"guest_vm":%s,"guest_vm_reason":%s}' \
         "$(_json_str "$kernel_release")" \
         "$(_json_str "$kernel_version")" \
         "$(_json_str "$kernel_arch")" \
@@ -121,7 +122,9 @@ _build_json_system() {
         "$(_json_num "${g_max_core_id:+$((g_max_core_id + 1))}")" \
         "$smt_val" \
         "$(_json_bool "${g_has_vmm:-}")" \
-        "$(_json_str "${g_has_vmm_reason:-}")")
+        "$(_json_str "${g_has_vmm_reason:-}")" \
+        "$(_json_bool "${g_is_guest_vm:-}")" \
+        "$(_json_str "${g_is_guest_vm_reason:-}")")
 }
 
 # Build the "cpu" section of the comprehensive JSON output
@@ -262,14 +265,15 @@ _build_json_cpu_microcode() {
         blacklisted='false'
     fi
     latest_hex="${ret_is_latest_known_ucode_version:-}"
-    g_json_cpu_microcode=$(printf '{"installed_version":%s,"latest_version":%s,"microcode_up_to_date":%s,"is_blacklisted":%s,"message":%s,"db_source":%s,"db_info":%s}' \
+    g_json_cpu_microcode=$(printf '{"installed_version":%s,"latest_version":%s,"microcode_up_to_date":%s,"is_blacklisted":%s,"message":%s,"db_source":%s,"db_info":%s,"unreliable_in_vm":%s}' \
         "$(_json_str "$ucode_hex")" \
         "$(_json_str "$latest_hex")" \
         "$ucode_uptodate" \
         "$blacklisted" \
         "$(_json_str "${ret_is_latest_known_ucode_latest:-}")" \
         "$(_json_str "${g_mcedb_source:-}")" \
-        "$(_json_str "${g_mcedb_info:-}")")
+        "$(_json_str "${g_mcedb_info:-}")" \
+        "$(_json_bool "${g_is_guest_vm:-}")")
 }
 
 # --- Format-specific batch emitters ---

--- a/src/libs/350_cpu_detect2.sh
+++ b/src/libs/350_cpu_detect2.sh
@@ -24,13 +24,22 @@ parse_cpu_details() {
         if grep -qw avx512 "$g_procfs/cpuinfo" 2>/dev/null; then cap_avx512=1; fi
         cpu_vendor=$(grep '^vendor_id' "$g_procfs/cpuinfo" | awk '{print $3}' | head -n1)
         cpu_friendly_name=$(grep '^model name' "$g_procfs/cpuinfo" | cut -d: -f2- | head -n1 | sed -e 's/^ *//')
-        # special case for ARM follows
-        if grep -qi 'CPU implementer[[:space:]]*:[[:space:]]*0x41' "$g_procfs/cpuinfo"; then
-            cpu_vendor='ARM'
-            # some devices (phones or other) have several ARMs and as such different part numbers,
-            # an example is "bigLITTLE", so we need to store the whole list, this is needed for is_cpu_affected
+        # ARM-style cpuinfo: parse per-core implementer/part/arch/variant/revision lists
+        # (big.LITTLE / heterogeneous systems have different values per core).
+        # cpu_variant_list and cpu_revision_list are consumed by ARM64 errata affection checks
+        # that need to match a specific revision range.
+        if grep -q 'CPU implementer' "$g_procfs/cpuinfo"; then
+            cpu_impl_list=$(awk '/CPU implementer/ {print $4}' "$g_procfs/cpuinfo")
             cpu_part_list=$(awk '/CPU part/         {print $4}' "$g_procfs/cpuinfo")
             cpu_arch_list=$(awk '/CPU architecture/ {print $3}' "$g_procfs/cpuinfo")
+            cpu_variant_list=$(awk '/CPU variant/   {print $4}' "$g_procfs/cpuinfo")
+            cpu_revision_list=$(awk '/CPU revision/ {print $4}' "$g_procfs/cpuinfo")
+        fi
+        # Map first-seen implementer to cpu_vendor; note that heterogeneous systems
+        # (e.g. DynamIQ with ARM+Kryo cores) would all map to one vendor here, but
+        # per-core vendor decisions are made via cpu_impl_list where needed.
+        if grep -qi 'CPU implementer[[:space:]]*:[[:space:]]*0x41' "$g_procfs/cpuinfo"; then
+            cpu_vendor='ARM'
             # take the first one to fill the friendly name, do NOT quote the vars below
             # shellcheck disable=SC2086
             arch=$(echo $cpu_arch_list | awk '{ print $1 }')

--- a/src/libs/370_hw_vmm.sh
+++ b/src/libs/370_hw_vmm.sh
@@ -55,3 +55,21 @@ is_xen_domU() {
         return 1
     fi
 }
+
+# Check whether the system is running as a guest inside a virtual machine.
+# Uses the 'hypervisor' CPUID feature flag exposed in /proc/cpuinfo by KVM,
+# VMware, Hyper-V, VirtualBox, and most other type-1 and type-2 hypervisors.
+# Returns: 0 if running as a VM guest, 1 otherwise
+# Sets: g_is_guest_vm (1=guest, 0=not a guest), g_is_guest_vm_reason
+is_running_as_guest() {
+    if [ "${g_is_guest_vm_cached:-0}" != 1 ]; then
+        g_is_guest_vm=0
+        g_is_guest_vm_reason=''
+        if [ -e "$g_procfs/cpuinfo" ] && grep -qw 'hypervisor' "$g_procfs/cpuinfo" 2>/dev/null; then
+            g_is_guest_vm=1
+            g_is_guest_vm_reason="'hypervisor' flag in $g_procfs/cpuinfo"
+        fi
+        g_is_guest_vm_cached=1
+    fi
+    [ "$g_is_guest_vm" = 1 ]
+}

--- a/src/libs/400_hw_check.sh
+++ b/src/libs/400_hw_check.sh
@@ -1367,11 +1367,19 @@ check_cpu() {
     fi
 }
 
-# Display per-CVE CPU vulnerability status based on CPU model/family
+# Display per-CVE CPU vulnerability status based on CPU model/family.
+# Mirrors the main dispatch gate: under a default "all CVEs" run, skip CVEs
+# whose arch tag doesn't match this system. Explicit selection via
+# --cve/--variant/--errata bypasses the gate.
 check_cpu_vulnerabilities() {
     local cve
     pr_info "* CPU vulnerability to the speculative execution attack variants"
     for cve in $g_supported_cve_list; do
+        if [ "$opt_cve_all" = 1 ]; then
+            _is_cve_relevant_arch "$cve" || continue
+        elif ! echo "$opt_cve_list" | grep -qw "$cve"; then
+            continue
+        fi
         pr_info_nol "  * Affected by $cve ($(cve2name "$cve")): "
         if is_cpu_affected "$cve"; then
             pstatus yellow YES

--- a/src/libs/400_hw_check.sh
+++ b/src/libs/400_hw_check.sh
@@ -1093,7 +1093,7 @@ check_cpu() {
         pr_info_nol "  * CPU explicitly indicates not being affected by MMIO Stale Data (FBSDP_NO & PSDP_NO & SBDR_SSDP_NO): "
         if [ "$cap_sbdr_ssdp_no" = -1 ]; then
             pstatus yellow UNKNOWN "couldn't read MSR"
-        elif [ "$cap_sbdr_ssdp_no" = 1 ] && [ "$cap_fbsdp_no" = 1 ] && [ "$cap_psdp_no" = 1 ]; then
+        elif is_arch_cap_mmio_immune; then
             pstatus green YES
         else
             pstatus yellow NO

--- a/src/libs/400_hw_check.sh
+++ b/src/libs/400_hw_check.sh
@@ -388,6 +388,30 @@ check_kernel_info() {
 check_cpu() {
     local capabilities ret spec_ctrl_msr codename ucode_str
 
+    if is_arm_cpu; then
+        pr_info "* CPU details"
+        pr_info "  * Vendor: $cpu_vendor"
+        pr_info "  * Model name: $cpu_friendly_name"
+        if [ -n "${cpu_impl_list:-}" ]; then
+            pr_info "  * Implementer(s): $cpu_impl_list"
+        fi
+        if [ -n "${cpu_part_list:-}" ]; then
+            pr_info "  * Part(s): $cpu_part_list"
+        fi
+        if [ -n "${cpu_arch_list:-}" ]; then
+            pr_info "  * Architecture(s): $cpu_arch_list"
+        fi
+        if has_runtime; then
+            pr_info_nol "  * Running as VM guest: "
+            if is_running_as_guest; then
+                pstatus yellow YES "$g_is_guest_vm_reason"
+            else
+                pstatus green NO
+            fi
+        fi
+        return
+    fi
+
     if ! uname -m | grep -qwE 'x86_64|i[3-6]86|amd64'; then
         return
     fi
@@ -413,6 +437,15 @@ check_cpu() {
         codename=$(get_intel_codename)
         if [ -n "$codename" ]; then
             pr_info "  * Codename: $codename"
+        fi
+    fi
+
+    if has_runtime; then
+        pr_info_nol "  * Running as VM guest: "
+        if is_running_as_guest; then
+            pstatus yellow YES "$g_is_guest_vm_reason"
+        else
+            pstatus green NO
         fi
     fi
 
@@ -1364,6 +1397,13 @@ check_cpu() {
         pstatus red NO "$ret_is_latest_known_ucode_latest"
     else
         pstatus blue UNKNOWN "$ret_is_latest_known_ucode_latest"
+    fi
+    if is_running_as_guest; then
+        pr_warn
+        pr_warn "Note: this system is running inside a VM ($g_is_guest_vm_reason)."
+        pr_warn "The hypervisor may be faking the CPU model and microcode version;"
+        pr_warn "verify the above microcode information on the hypervisor host for accuracy."
+        pr_warn
     fi
 }
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -43,10 +43,19 @@ if [ "$g_mode" = hw-only ]; then
     pr_info "Hardware-only mode, skipping vulnerability checks"
 else
     for cve in $g_supported_cve_list; do
-        if [ "$opt_cve_all" = 1 ] || echo "$opt_cve_list" | grep -qw "$cve"; then
-            check_"$(echo "$cve" | tr - _)"
-            pr_info
+        # In a default "all CVEs" run, skip checks whose arch tag doesn't match
+        # the host CPU or the inspected kernel. Explicit --cve/--variant/--errata
+        # selection bypasses the gate.
+        if [ "$opt_cve_all" = 1 ]; then
+            if ! _is_cve_relevant_arch "$cve"; then
+                pr_debug "main: skipping $cve (arch tag not relevant)"
+                continue
+            fi
+        elif ! echo "$opt_cve_list" | grep -qw "$cve"; then
+            continue
         fi
+        check_"$(echo "$cve" | tr - _)"
+        pr_info
     done
 fi # g_mode != hw-only
 

--- a/src/vulns-helpers/check_mmio.sh
+++ b/src/vulns-helpers/check_mmio.sh
@@ -1,16 +1,30 @@
 # vim: set ts=4 sw=4 sts=4 et:
 # MMIO Stale Data (Processor MMIO Stale Data Vulnerabilities) - BSD mitigation check
 check_mmio_bsd() {
+    # No BSD (FreeBSD, OpenBSD, NetBSD, DragonFlyBSD) has implemented an OS-level
+    # MMIO Stale Data mitigation. All four stopped at MDS/TAA. Microcode update is
+    # the only partial defense available, and without OS-level VERW invocation it
+    # cannot close the vulnerability.
+    local unk
+    unk="your CPU's MMIO Stale Data status is unknown (Intel never officially assessed this CPU, its servicing period has ended)"
     if ! is_cpu_affected "$cve"; then
         pvulnstatus "$cve" OK "your CPU vendor reported your CPU model as not affected"
+    elif is_cpu_mmio_unknown; then
+        if [ "$opt_paranoid" = 1 ]; then
+            pvulnstatus "$cve" VULN "$unk, and no BSD mitigation exists"
+            explain "There is no known mitigation for this CPU model. Even with up-to-date microcode, BSD kernels do not invoke VERW for MMIO Stale Data clearing. Only a hardware replacement can fully address this."
+        else
+            pvulnstatus "$cve" UNK "$unk; no BSD mitigation exists in any case"
+        fi
     else
-        pvulnstatus "$cve" UNK "your CPU is affected, but mitigation detection has not yet been implemented for BSD in this script"
+        pvulnstatus "$cve" VULN "your CPU is affected and no BSD has implemented an MMIO Stale Data mitigation"
+        explain "No BSD kernel currently implements an MMIO Stale Data mitigation (which would require invoking VERW at context switches and VM-entries). Updating CPU microcode alone does not mitigate this vulnerability without OS cooperation."
     fi
 }
 
 # MMIO Stale Data (Processor MMIO Stale Data Vulnerabilities) - Linux mitigation check
 check_mmio_linux() {
-    local status sys_interface_available msg kernel_mmio kernel_mmio_can_tell mmio_mitigated mmio_smt_mitigated mystatus mymsg
+    local status sys_interface_available msg kernel_mmio kernel_mmio_can_tell mmio_mitigated mmio_smt_mitigated mystatus mymsg unk
     status=UNK
     sys_interface_available=0
     msg=''
@@ -112,9 +126,33 @@ check_mmio_linux() {
         #
         # No models have been added to or removed from the MMIO blacklist since v5.19.
         #
+        # 7df548840c49 (v6.0, NO_MMIO whitelist added, Pawan Gupta 2022-08-03):
+        #   Intel Family 6:
+        #     TIGERLAKE (0x8D), TIGERLAKE_L (0x8C)
+        #     ALDERLAKE (0x97), ALDERLAKE_L (0x9A)
+        #     ATOM_GOLDMONT (0x5C), ATOM_GOLDMONT_D (0x5F), ATOM_GOLDMONT_PLUS (0x7A)
+        #   AMD: fam 0x0f-0x12 + X86_FAMILY_ANY (all families)
+        #   Hygon: all families
+        #   Centaur fam 7, Zhaoxin fam 7
+        #
+        # Kernel logic (v6.0+):
+        #   if (!arch_cap_mmio_immune(ia32_cap)) {
+        #       if (cpu_matches(cpu_vuln_blacklist, MMIO))
+        #           setup_force_cpu_bug(X86_BUG_MMIO_STALE_DATA);
+        #       else if (!cpu_matches(cpu_vuln_whitelist, NO_MMIO))
+        #           setup_force_cpu_bug(X86_BUG_MMIO_UNKNOWN);
+        #   }
+        #   => Intel CPUs that are neither blacklisted nor whitelisted (e.g. Ivy Bridge,
+        #      Haswell client, Broadwell client, Sandy Bridge, pre-Goldmont Atom, etc.) get
+        #      X86_BUG_MMIO_UNKNOWN and report "Unknown: No mitigations" in sysfs. Intel
+        #      never published an affected-processor evaluation for these models because
+        #      their servicing period had already ended.
+        #   => is_cpu_mmio_unknown() matches this set so the script can report UNK (or
+        #      VULN under --paranoid) rather than the misleading "not affected" that
+        #      a plain blacklist check would produce.
+        #
         # immunity: ARCH_CAP_SBDR_SSDP_NO (bit 13) AND ARCH_CAP_FBSDP_NO (bit 14) AND ARCH_CAP_PSDP_NO (bit 15)
         #   All three must be set. Checked via arch_cap_mmio_immune() in common.c.
-        #   Bug is set only when: cpu_matches(blacklist, MMIO) AND NOT arch_cap_mmio_immune().
         #
         # microcode mitigation: ARCH_CAP_FB_CLEAR (bit 17) -- VERW clears fill buffers.
         #   Alternative: MD_CLEAR CPUID + FLUSH_L1D CPUID when MDS_NO is not set (legacy path).
@@ -193,6 +231,17 @@ check_mmio_linux() {
     if ! is_cpu_affected "$cve"; then
         # override status & msg in case CPU is not vulnerable after all
         pvulnstatus "$cve" OK "your CPU vendor reported your CPU model as not affected"
+    elif [ "$opt_sysfs_only" != 1 ] && is_cpu_mmio_unknown; then
+        # Bypass the normal sysfs reconciliation: sysfs reports "Unknown: No mitigations"
+        # only on v6.0-v6.15. On earlier and on v6.16+ kernels it wrongly says "Not affected"
+        # for these CPUs (which predate FB_CLEAR microcode and Intel's affected-processor list).
+        unk="your CPU's MMIO Stale Data status is unknown (Intel never officially assessed this CPU, its servicing period has ended)"
+        if [ "$opt_paranoid" = 1 ]; then
+            pvulnstatus "$cve" VULN "$unk, and no mitigation is available"
+            explain "There is no known mitigation for this CPU model. Intel ended its servicing period without evaluating whether it is affected by MMIO Stale Data vulnerabilities, so no FB_CLEAR-capable microcode was released. Consider replacing affected hardware."
+        else
+            pvulnstatus "$cve" UNK "$unk; no mitigation is available in any case"
+        fi
     else
         if [ "$opt_sysfs_only" != 1 ]; then
             # compute mystatus and mymsg from our own logic

--- a/src/vulns/CVE-0001-0001.sh
+++ b/src/vulns/CVE-0001-0001.sh
@@ -1,0 +1,78 @@
+# vim: set ts=4 sw=4 sts=4 et:
+###############################
+# CVE-0001-0001, ARM SPEC AT, ARM64 errata 1165522/1319367/1319537/1530923, Speculative AT TLB corruption
+
+check_CVE_0001_0001() {
+    check_cve 'CVE-0001-0001'
+}
+
+# On affected cores, a speculative address translation (AT) instruction issued from the hypervisor
+# using an out-of-context translation regime may poison the TLB, causing a subsequent guest-context
+# request to see an incorrect translation. Relevant mainly to KVM hosts. Kernel workaround:
+# invalidate TLB state across world-switch for affected cores (ARM64_WORKAROUND_SPECULATIVE_AT).
+#   * Cortex-A76 r0p0..r2p0   erratum 1165522   CONFIG_ARM64_ERRATUM_1165522
+#   * Cortex-A72 all revs     erratum 1319367   CONFIG_ARM64_ERRATUM_1319367
+#   * Cortex-A57 all revs     erratum 1319537   CONFIG_ARM64_ERRATUM_1319367 (same kconfig)
+#   * Cortex-A55 r0p0..r2p0   erratum 1530923   CONFIG_ARM64_ERRATUM_1530923
+# References:
+#   arch/arm64/Kconfig (ARM64_ERRATUM_{1165522,1319367,1530923})
+#   arch/arm64/kernel/cpu_errata.c (erratum_speculative_at_list, "ARM errata 1165522, 1319367, or 1530923")
+#   Cortex-A55 SDEN: https://developer.arm.com/documentation/SDEN-1301074/latest
+check_CVE_0001_0001_linux() {
+    local cve kernel_mitigated config_found
+    cve='CVE-0001-0001'
+    kernel_mitigated=''
+    config_found=''
+
+    if [ "$opt_sysfs_only" != 1 ] && is_arm_kernel; then
+        # kconfig: any of the three erratum config options implies the workaround is compiled in
+        if [ -n "$opt_config" ]; then
+            for erratum in 1165522 1319367 1530923; do
+                if grep -q "^CONFIG_ARM64_ERRATUM_$erratum=y" "$opt_config"; then
+                    config_found="${config_found:+$config_found, }$erratum"
+                fi
+            done
+            [ -n "$config_found" ] && kernel_mitigated="found CONFIG_ARM64_ERRATUM_$config_found=y in kernel config"
+        fi
+        # kernel image: look for the descriptor string the kernel prints at boot
+        if [ -z "$kernel_mitigated" ] && [ -n "$g_kernel" ]; then
+            if "${opt_arch_prefix}strings" "$g_kernel" 2>/dev/null | grep -qE 'ARM errata 1165522, 1319367'; then
+                kernel_mitigated="found erratum descriptor string in kernel image"
+            fi
+        fi
+        # live mode: dmesg prints the workaround once at boot
+        if [ -z "$kernel_mitigated" ] && [ "$g_mode" = live ]; then
+            if dmesg 2>/dev/null | grep -qE 'ARM errata 1165522, 1319367'; then
+                kernel_mitigated="erratum workaround reported as applied in dmesg"
+            fi
+        fi
+
+        pr_info_nol "* Kernel has the ARM64 Speculative-AT workaround compiled in: "
+        if [ -n "$kernel_mitigated" ]; then
+            pstatus green YES "$kernel_mitigated"
+        else
+            pstatus yellow NO
+        fi
+    fi
+
+    if ! is_cpu_affected "$cve"; then
+        pvulnstatus "$cve" OK "your CPU is not affected by this erratum family"
+    elif [ "$opt_sysfs_only" = 1 ]; then
+        pvulnstatus "$cve" UNK "no sysfs interface exists for this erratum, own checks have been skipped (--sysfs-only)"
+    elif [ -n "$kernel_mitigated" ]; then
+        pvulnstatus "$cve" OK "your kernel includes the erratum workaround"
+    else
+        pvulnstatus "$cve" VULN "your CPU is affected by this erratum family and the kernel does not appear to include the workaround"
+        explain "Run a kernel built with CONFIG_ARM64_ERRATUM_1165522=y, CONFIG_ARM64_ERRATUM_1319367=y, and/or CONFIG_ARM64_ERRATUM_1530923=y (matching your CPU core). These options are 'default y' in mainline and enabled by most distro kernels. Refer to the ARM Software Developers Errata Notice for your core for full details."
+    fi
+}
+
+check_CVE_0001_0001_bsd() {
+    local cve
+    cve='CVE-0001-0001'
+    if ! is_cpu_affected "$cve"; then
+        pvulnstatus "$cve" OK "your CPU is not affected by this erratum family"
+    else
+        pvulnstatus "$cve" UNK "your CPU is affected, but mitigation detection has not yet been implemented for BSD in this script"
+    fi
+}

--- a/src/vulns/CVE-0001-0002.sh
+++ b/src/vulns/CVE-0001-0002.sh
@@ -1,0 +1,75 @@
+# vim: set ts=4 sw=4 sts=4 et:
+###############################
+# CVE-0001-0002, ARM SPEC UNPRIV LOAD, ARM64 errata 2966298/3117295, Speculative unprivileged load
+
+check_CVE_0001_0002() {
+    check_cve 'CVE-0001-0002'
+}
+
+# On affected cores, a speculatively-executed unprivileged load from a page that is mapped as
+# privileged can leak the loaded value into the cache hierarchy, allowing a Spectre-style
+# cache side-channel to expose privileged kernel data to userspace. Kernel workaround:
+# sandwich kernel-exit sequences with an additional speculation barrier/DSB so that
+# speculative unprivileged loads cannot observe privileged state
+# (ARM64_WORKAROUND_SPECULATIVE_UNPRIV_LOAD).
+#   * Cortex-A510 all revs    erratum 3117295   CONFIG_ARM64_ERRATUM_3117295
+#   * Cortex-A520 r0p0..r0p1  erratum 2966298   CONFIG_ARM64_ERRATUM_2966298
+# References:
+#   arch/arm64/Kconfig (ARM64_ERRATUM_{2966298,3117295})
+#   arch/arm64/kernel/cpu_errata.c (erratum_spec_unpriv_load_list, "ARM errata 2966298, 3117295")
+#   Cortex-A510 SDEN: https://developer.arm.com/documentation/SDEN-2397239/latest
+check_CVE_0001_0002_linux() {
+    local cve kernel_mitigated config_found erratum
+    cve='CVE-0001-0002'
+    kernel_mitigated=''
+    config_found=''
+
+    if [ "$opt_sysfs_only" != 1 ] && is_arm_kernel; then
+        if [ -n "$opt_config" ]; then
+            for erratum in 2966298 3117295; do
+                if grep -q "^CONFIG_ARM64_ERRATUM_$erratum=y" "$opt_config"; then
+                    config_found="${config_found:+$config_found, }$erratum"
+                fi
+            done
+            [ -n "$config_found" ] && kernel_mitigated="found CONFIG_ARM64_ERRATUM_$config_found=y in kernel config"
+        fi
+        if [ -z "$kernel_mitigated" ] && [ -n "$g_kernel" ]; then
+            if "${opt_arch_prefix}strings" "$g_kernel" 2>/dev/null | grep -qE 'ARM errata 2966298, 3117295'; then
+                kernel_mitigated="found erratum descriptor string in kernel image"
+            fi
+        fi
+        if [ -z "$kernel_mitigated" ] && [ "$g_mode" = live ]; then
+            if dmesg 2>/dev/null | grep -qE 'ARM errata 2966298, 3117295'; then
+                kernel_mitigated="erratum workaround reported as applied in dmesg"
+            fi
+        fi
+
+        pr_info_nol "* Kernel has the ARM64 Speculative-Unprivileged-Load workaround compiled in: "
+        if [ -n "$kernel_mitigated" ]; then
+            pstatus green YES "$kernel_mitigated"
+        else
+            pstatus yellow NO
+        fi
+    fi
+
+    if ! is_cpu_affected "$cve"; then
+        pvulnstatus "$cve" OK "your CPU is not affected by this erratum family"
+    elif [ "$opt_sysfs_only" = 1 ]; then
+        pvulnstatus "$cve" UNK "no sysfs interface exists for this erratum, own checks have been skipped (--sysfs-only)"
+    elif [ -n "$kernel_mitigated" ]; then
+        pvulnstatus "$cve" OK "your kernel includes the erratum workaround"
+    else
+        pvulnstatus "$cve" VULN "your CPU is affected by this erratum family and the kernel does not appear to include the workaround"
+        explain "Run a kernel built with CONFIG_ARM64_ERRATUM_2966298=y (Cortex-A520) and/or CONFIG_ARM64_ERRATUM_3117295=y (Cortex-A510). These options are 'default y' in mainline and enabled by most distro kernels. Refer to the ARM Software Developers Errata Notice for your core for full details."
+    fi
+}
+
+check_CVE_0001_0002_bsd() {
+    local cve
+    cve='CVE-0001-0002'
+    if ! is_cpu_affected "$cve"; then
+        pvulnstatus "$cve" OK "your CPU is not affected by this erratum family"
+    else
+        pvulnstatus "$cve" UNK "your CPU is affected, but mitigation detection has not yet been implemented for BSD in this script"
+    fi
+}

--- a/src/vulns/CVE-0001-0003.sh
+++ b/src/vulns/CVE-0001-0003.sh
@@ -1,0 +1,70 @@
+# vim: set ts=4 sw=4 sts=4 et:
+###############################
+# CVE-0001-0003, ARM SSBS NOSYNC, ARM64 erratum 3194386, MSR SSBS not self-synchronizing
+
+check_CVE_0001_0003() {
+    check_cve 'CVE-0001-0003'
+}
+
+# On affected cores, the "MSR SSBS, #x" instruction is not self-synchronizing, so subsequent
+# speculative instructions may execute without observing the new SSBS state. This can permit
+# unintended speculative store bypass (Spectre V4 / CVE-2018-3639) even when software thinks
+# the mitigation is in effect. Kernel workaround (ARM64_WORKAROUND_SPECULATIVE_SSBS):
+#   - place a Speculation Barrier (SB) or ISB after every kernel-side SSBS change
+#   - hide SSBS from userspace hwcaps and EL0 reads of ID_AA64PFR1_EL1 so that userspace
+#     routes SSB mitigation changes through the prctl(PR_SET_SPECULATION_CTRL) path
+# Affected cores (via ARM64_ERRATUM_3194386, with individual sub-errata numbers):
+#   Cortex-A76/A77/A78/A78C/A710/A715/A720/A720AE/A725, X1/X1C/X2/X3/X4/X925,
+#   Neoverse-N1/N2/N3, Neoverse-V1/V2/V3/V3AE
+# References:
+#   arch/arm64/Kconfig (ARM64_ERRATUM_3194386)
+#   arch/arm64/kernel/cpu_errata.c (erratum_spec_ssbs_list, "SSBS not fully self-synchronizing")
+check_CVE_0001_0003_linux() {
+    local cve kernel_mitigated
+    cve='CVE-0001-0003'
+    kernel_mitigated=''
+
+    if [ "$opt_sysfs_only" != 1 ] && is_arm_kernel; then
+        if [ -n "$opt_config" ] && grep -q '^CONFIG_ARM64_ERRATUM_3194386=y' "$opt_config"; then
+            kernel_mitigated="found CONFIG_ARM64_ERRATUM_3194386=y in kernel config"
+        fi
+        if [ -z "$kernel_mitigated" ] && [ -n "$g_kernel" ]; then
+            if "${opt_arch_prefix}strings" "$g_kernel" 2>/dev/null | grep -qE 'SSBS not fully self-synchronizing'; then
+                kernel_mitigated="found erratum descriptor string in kernel image"
+            fi
+        fi
+        if [ -z "$kernel_mitigated" ] && [ "$g_mode" = live ]; then
+            if dmesg 2>/dev/null | grep -qE 'SSBS not fully self-synchronizing'; then
+                kernel_mitigated="erratum workaround reported as applied in dmesg"
+            fi
+        fi
+
+        pr_info_nol "* Kernel has the ARM64 SSBS self-sync workaround compiled in: "
+        if [ -n "$kernel_mitigated" ]; then
+            pstatus green YES "$kernel_mitigated"
+        else
+            pstatus yellow NO
+        fi
+    fi
+
+    if ! is_cpu_affected "$cve"; then
+        pvulnstatus "$cve" OK "your CPU is not affected by this erratum"
+    elif [ "$opt_sysfs_only" = 1 ]; then
+        pvulnstatus "$cve" UNK "no sysfs interface exists for this erratum, own checks have been skipped (--sysfs-only)"
+    elif [ -n "$kernel_mitigated" ]; then
+        pvulnstatus "$cve" OK "your kernel includes the erratum workaround"
+    else
+        pvulnstatus "$cve" VULN "your CPU is affected by this erratum and the kernel does not appear to include the workaround; Spectre V4 (CVE-2018-3639) mitigation may be unreliable on this system"
+        explain "Run a kernel built with CONFIG_ARM64_ERRATUM_3194386=y. This option is 'default y' in mainline and enabled by most distro kernels. Without it, the Spectre V4 / speculative-store-bypass mitigation advertised by SSBS is not reliably applied. Userspace should use prctl(PR_SET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS, ...) to request the mitigation rather than rely on the SSBS hwcap."
+    fi
+}
+
+check_CVE_0001_0003_bsd() {
+    local cve
+    cve='CVE-0001-0003'
+    if ! is_cpu_affected "$cve"; then
+        pvulnstatus "$cve" OK "your CPU is not affected by this erratum"
+    else
+        pvulnstatus "$cve" UNK "your CPU is affected, but mitigation detection has not yet been implemented for BSD in this script"
+    fi
+}


### PR DESCRIPTION
# Release highlights

This release brings some features to **ARM64** hosts. They get dedicated silicon-errata checks, a proper CPU details block, and architecture-aware filtering so x86 hosts no longer show ARM64 noise and vice-versa.

On the x86 side, MMIO Stale Data detection is now much more honest about **end-of-life Intel CPUs** that Intel never officially assessed, these are now reported as `UNK` (or `VULN` under `--paranoid`) instead of a misleading "not affected".

The tool now better detects guest environments and warns you that the microcode version reported by your hypervisor may be fake or stale, so the "up-to-date microcode" check can't be trusted from inside the guest.

# More detailed changelog

### Add ARM64 silicon errata (issue #357)
Three speculation/security-relevant ARM64 errata families are now detected. As these are tracked by vendor erratum IDs rather than CVEs, a new `CVE-0001-NNNN` placeholder range has been reserved for vendor errata, along with a new `--errata <number>` selector (alongside `--variant`/`--cve`):

- **Speculative AT TLB corruption** (1165522 / 1319367 / 1319537 / 1530923)
- **Speculative unprivileged load** (2966298 / 3117295)
- **MSR SSBS not self-synchronizing** (3194386 and siblings)

CPU affectedness is determined per-core from the `(implementer, part, variant, revision)` tuple in `/proc/cpuinfo`, matching the kernel code. Kernel mitigation detection relies on the per-erratum `CONFIG_ARM64_ERRATUM_NNNN` symbols, kernel image descriptor strings, and dmesg (no sysfs exists for these).

### Architecture-aware CVE filtering
- `CVE_REGISTRY` gains an optional fifth field tagging checks as **x86-only** or **arm-only**; untagged entries apply everywhere.
- Default "all CVEs" runs now skip checks irrelevant to the inspected architecture across **text, JSON, NRPE and Prometheus** outputs (no more ARM64 errata on x86 hosts, or x86 CVEs on ARM hosts).
- Explicit `--cve` / `--variant` / `--errata` selection bypasses the check, so manual queries still run anywhere.
- In `--no-hw` mode, the host CPU is ignored, supporting cross-arch offline analysis driven by `--kernel`/`--config`/`--map`.

### Fixes to existing CVEs
- **MMIO Stale Data (CVE-2022-21123 / 21125 / 21166) (#437):** EOL Intel CPUs that Intel never officially assessed (Sandy/Ivy Bridge, Haswell/Broadwell client, pre-Goldmont Atom, etc.) are now reported as `UNK` (or `VULN` under `--paranoid`) instead of a misleading "not affected". This corrects the picture on kernels where sysfs wrongly says "Not affected" (pre-v6.0 and v6.16+) and aligns with the kernel's `X86_BUG_MMIO_UNKNOWN` set. The BSD path was corrected too: no BSD implements an MMIO mitigation, so affected CPUs now report `VULN` (with an `explain` rationale) rather than "not yet implemented".

### VM guest detection (issue #336)
- New `is_running_as_guest()` detects VM guests (KVM, VMware, ESXi, Hyper-V, VirtualBox…) via the `hypervisor` CPUID flag in `/proc/cpuinfo`.
- New **"Running as VM guest: YES/NO"** line in the CPU details block (x86 and ARM).
- A warning is now emitted after the microcode-is-latest check, advising you to verify microcode on the hypervisor host, since a guest can be shown a fake CPUID/microcode version.
- JSON output exposes this: `system.guest_vm` (bool), `system.guest_vm_reason` (string), and `cpu_microcode.unreliable_in_vm` (bool).

### Output display
- ARM CPUs now get a proper CPU details block in `check_cpu()`: vendor, model name, implementer(s), part(s), architecture(s) and VM-guest status. Previously the x86-only early return left ARM hosts with no `check_cpu()` output at all.

### Tooling
- New `scripts/update_mcedb.sh` (on test and source branches), so that the GitHub workflow can regenerate `src/db/200_mcedb.sh` daily.

### Documentation
- **Unsupported CVE list:** added the **Jump Conditional Code (JCC) Erratum** (issue #329), a microarchitectural correctness bug (Skylake to Cascade Lake), not a speculative side channel, with no CVE, no sysfs/CPUID/MSR indicator, hence out of scope.